### PR TITLE
Implement Demo App Showcase

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/App.kt
@@ -1,30 +1,23 @@
 package com.jesusdmedinac.compose.sdui
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.remember
 import com.jesusdmedinac.jsontocompose.LocalBehavior
 import com.jesusdmedinac.jsontocompose.LocalCustomRenderers
 import com.jesusdmedinac.jsontocompose.LocalDrawableResources
 import com.jesusdmedinac.jsontocompose.LocalStateHost
 import com.jesusdmedinac.jsontocompose.ToCompose
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import com.jesusdmedinac.jsontocompose.behavior.Behavior
-import com.jesusdmedinac.jsontocompose.com.jesusdmedinac.jsontocompose.state.MutableStateHost
 import com.jesusdmedinac.jsontocompose.com.jesusdmedinac.jsontocompose.state.StateHost
-import com.jesusdmedinac.jsontocompose.model.ComposeModifier
 import com.jesusdmedinac.jsontocompose.model.ComposeNode
 import com.jesusdmedinac.jsontocompose.model.ComposeType
 import com.jesusdmedinac.jsontocompose.model.NodeProperties
 import json_to_compose.composeapp.generated.resources.Res
 import json_to_compose.composeapp.generated.resources.compose_multiplatform
+import kotlinx.serialization.json.jsonPrimitive
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
@@ -35,55 +28,8 @@ fun App() {
         "compose-multiplatform" to Res.drawable.compose_multiplatform
     )
 
-    val textFieldHost = remember { MutableStateHost("") }
-    val dialogHost = remember { MutableStateHost(false) }
-    val switchStateHost = remember { MutableStateHost(false) }
-    val switchEnabledHost = remember { MutableStateHost(true) }
-    val checkboxCheckedHost = remember { MutableStateHost(false) }
-    val checkboxEnabledHost = remember { MutableStateHost(true) }
-
-    val behaviors = mapOf(
-        "button_clicked" to object : Behavior {
-            override fun invoke() {
-                println("Button clicked: button_clicked")
-            }
-        },
-        "show_dialog" to object : Behavior {
-            override fun invoke() {
-                dialogHost.onStateChange(true)
-            }
-        },
-        "dialog_confirm" to object : Behavior {
-            override fun invoke() {
-                println("Dialog confirmed")
-                dialogHost.onStateChange(false)
-            }
-        },
-        "dialog_dismiss" to object : Behavior {
-            override fun invoke() {
-                println("Dialog dismissed")
-                dialogHost.onStateChange(false)
-            }
-        },
-        "switch_toggled" to object : Behavior {
-            override fun invoke() {
-                println("Switch toggled: ${switchStateHost.state}")
-            }
-        },
-        "checkbox_toggled" to object : Behavior {
-            override fun invoke() {
-                println("Checkbox toggled: ${checkboxCheckedHost.state}")
-            }
-        }
-    )
-    val stateHosts = mapOf<String, StateHost<*>>(
-        "text_field_value" to textFieldHost,
-        "dialog_visibility" to dialogHost,
-        "switch_state" to switchStateHost,
-        "checkbox_checked" to checkboxCheckedHost,
-        "checkbox_enabled" to checkboxEnabledHost,
-        "switch_enabled" to switchEnabledHost,
-    )
+    // Load State and Behaviors
+    val showcaseState = rememberShowcaseState()
 
     val customRenderers: Map<String, @Composable (ComposeNode) -> Unit> = mapOf(
         "ProductCard" to { node ->
@@ -98,500 +44,101 @@ fun App() {
         }
     )
 
+    // Construct the UI Tree
+    val sections = listOf(
+        layoutSection(),
+        contentSection(),
+        inputSection(),
+        containerSection(),
+        navigationSection(),
+        lazyListSection(),
+        modifiersSection(),
+        customSection()
+    ).flatten()
+
+    val rootScaffold = ComposeNode(
+        type = ComposeType.Scaffold,
+        properties = NodeProperties.ScaffoldProps(
+            topBar = ComposeNode(
+                type = ComposeType.TopAppBar,
+                properties = NodeProperties.TopAppBarProps(
+                    title = ComposeNode(
+                        type = ComposeType.Text,
+                        properties = NodeProperties.TextProps(
+                            text = "JSON to Compose Showcase"
+                        )
+                    )
+                )
+            ),
+            bottomBar = ComposeNode(
+                type = ComposeType.BottomBar,
+                properties = NodeProperties.BottomBarProps(
+                    children = listOf(
+                        ComposeNode(
+                            type = ComposeType.BottomNavigationItem,
+                            properties = NodeProperties.BottomNavigationItemProps(
+                                selectedStateHostName = "nav_home_selected",
+                                onClickEventName = "onNavHome",
+                                label = ComposeNode(
+                                    type = ComposeType.Text,
+                                    properties = NodeProperties.TextProps(text = "Home")
+                                ),
+                                icon = ComposeNode(
+                                    type = ComposeType.Text,
+                                    properties = NodeProperties.TextProps(text = "H")
+                                )
+                            )
+                        ),
+                        ComposeNode(
+                            type = ComposeType.BottomNavigationItem,
+                            properties = NodeProperties.BottomNavigationItemProps(
+                                selectedStateHostName = "nav_search_selected",
+                                onClickEventName = "onNavSearch",
+                                label = ComposeNode(
+                                    type = ComposeType.Text,
+                                    properties = NodeProperties.TextProps(text = "Search")
+                                ),
+                                icon = ComposeNode(
+                                    type = ComposeType.Text,
+                                    properties = NodeProperties.TextProps(text = "S")
+                                )
+                            )
+                        ),
+                        ComposeNode(
+                            type = ComposeType.BottomNavigationItem,
+                            properties = NodeProperties.BottomNavigationItemProps(
+                                selectedStateHostName = "nav_profile_selected",
+                                onClickEventName = "onNavProfile",
+                                label = ComposeNode(
+                                    type = ComposeType.Text,
+                                    properties = NodeProperties.TextProps(text = "Profile")
+                                ),
+                                icon = ComposeNode(
+                                    type = ComposeType.Text,
+                                    properties = NodeProperties.TextProps(text = "P")
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            child = ComposeNode(
+                type = ComposeType.LazyColumn,
+                properties = NodeProperties.ColumnProps(
+                    children = sections
+                )
+            )
+        )
+    )
+
     CompositionProviders(
         drawableResources = drawableResources,
-        behaviors = behaviors,
-        stateHosts = stateHosts,
+        behaviors = showcaseState.behaviors,
+        stateHosts = showcaseState.stateHosts,
         customRenderers = customRenderers,
     ) {
         MaterialTheme {
-            val composeNode = ComposeNode(
-                type = ComposeType.Column,
-                properties = NodeProperties.ColumnProps(
-                    children = listOf(
-                        ComposeNode(
-                            type = ComposeType.Text,
-                            properties = NodeProperties.TextProps(
-                                text = "Text Node"
-                            ),
-                        ),
-                        ComposeNode(
-                            type = ComposeType.Button,
-                            properties = NodeProperties.ButtonProps(
-                                onClickEventName = "button_clicked",
-                                child = ComposeNode(
-                                    type = ComposeType.Text,
-                                    properties = NodeProperties.TextProps(
-                                        text = "Button Node"
-                                    )
-                                )
-                            )
-                        ),
-                        ComposeNode(
-                            type = ComposeType.Image,
-                            properties = NodeProperties.ImageProps(
-                                url = "https://relatos.jesusdmedinac.com/_astro/carta-al-lector.OLllKYCu_Z1cdMQV.webp",
-                                contentDescription = "Image Node from url",
-                                contentScale = "Fit"
-                            )
-                        ),
-                        ComposeNode(
-                            type = ComposeType.Image,
-                            properties = NodeProperties.ImageProps(
-                                resourceName = "compose-multiplatform",
-                                contentDescription = "Image Node from resource",
-                                contentScale = "Fit"
-                            )
-                        ),
-                        ComposeNode(
-                            type = ComposeType.Column,
-                            properties = NodeProperties.ColumnProps(
-                                children = listOf(
-                                    ComposeNode(
-                                        type = ComposeType.Text,
-                                        properties = NodeProperties.TextProps(
-                                            text = "First text"
-                                        )
-                                    ),
-                                    ComposeNode(
-                                        type = ComposeType.Text,
-                                        properties = NodeProperties.TextProps(
-                                            text = "Second text"
-                                        )
-                                    ),
-                                )
-                            )
-                        ),
-                        ComposeNode(
-                            type = ComposeType.Row,
-                            properties = NodeProperties.RowProps(
-                                children = listOf(
-                                    ComposeNode(
-                                        type = ComposeType.Text,
-                                        properties = NodeProperties.TextProps(
-                                            text = "First text"
-                                        )
-                                    ),
-                                    ComposeNode(
-                                        type = ComposeType.Text,
-                                        properties = NodeProperties.TextProps(
-                                            text = "Second text"
-                                        )
-                                    ),
-                                )
-                            )
-                        ),
-                        ComposeNode(
-                            type = ComposeType.Box,
-                            properties = NodeProperties.BoxProps(
-                                children = listOf(
-                                    ComposeNode(
-                                        type = ComposeType.Text,
-                                        properties = NodeProperties.TextProps(
-                                            text = "First text"
-                                        )
-                                    ),
-                                    ComposeNode(
-                                        type = ComposeType.Text,
-                                        properties = NodeProperties.TextProps(
-                                            text = "Second text"
-                                        )
-                                    ),
-                                )
-                            )
-                        ),
-                        ComposeNode(
-                            type = ComposeType.TextField,
-                            properties = NodeProperties.TextFieldProps(
-                                valueStateHostName = "text_field_value"
-                            )
-                        ),
-                        ComposeNode(
-                            type = ComposeType.Switch,
-                            properties = NodeProperties.SwitchProps(
-                                checkedStateHostName = "switch_state",
-                                onCheckedChangeEventName = "switch_toggled",
-                                enabledStateHostName = "switch_enabled",
-                            )
-                        ),
-                        ComposeNode(
-                            type = ComposeType.Row,
-                            properties = NodeProperties.RowProps(
-                                children = listOf(
-                                    ComposeNode(
-                                        type = ComposeType.Checkbox,
-                                        properties = NodeProperties.CheckboxProps(
-                                            checkedStateHostName = "checkbox_checked",
-                                            onCheckedChangeEventName = "checkbox_toggled",
-                                            enabledStateHostName = "checkbox_enabled",
-                                        )
-                                    ),
-                                    ComposeNode(
-                                        type = ComposeType.Text,
-                                        properties = NodeProperties.TextProps(
-                                            text = "Accept terms and conditions"
-                                        )
-                                    ),
-                                )
-                            )
-                        ),
-                        ComposeNode(
-                            type = ComposeType.LazyColumn,
-                            composeModifier = ComposeModifier(
-                                operations = listOf(
-                                    ComposeModifier.Operation.FillMaxWidth,
-                                    ComposeModifier.Operation.Height(64),
-                                )
-                            ),
-                            properties = NodeProperties.ColumnProps(
-                                children = listOf(
-                                    ComposeNode(
-                                        type = ComposeType.Text,
-                                        properties = NodeProperties.TextProps(
-                                            text = "First text on lazy column"
-                                        ),
-                                    ),
-                                    ComposeNode(
-                                        type = ComposeType.Text,
-                                        properties = NodeProperties.TextProps(
-                                            text = "Second text on lazy column"
-                                        ),
-                                    ),
-                                    ComposeNode(
-                                        type = ComposeType.Text,
-                                        properties = NodeProperties.TextProps(
-                                            text = "Third text on lazy column"
-                                        ),
-                                    ),
-                                    ComposeNode(
-                                        type = ComposeType.Text,
-                                        properties = NodeProperties.TextProps(
-                                            text = "Fourth text on lazy column"
-                                        ),
-                                    ),
-                                ),
-                            ),
-                        ),
-                        ComposeNode(
-                            type = ComposeType.LazyRow,
-                            composeModifier = ComposeModifier(
-                                operations = listOf(
-                                    ComposeModifier.Operation.FillMaxWidth,
-                                    ComposeModifier.Operation.Width(64),
-                                )
-                            ),
-                            properties = NodeProperties.RowProps(
-                                children = listOf(
-                                    ComposeNode(
-                                        type = ComposeType.Text,
-                                        properties = NodeProperties.TextProps(
-                                            text = "First text on lazy row"
-                                        ),
-                                    ),
-                                    ComposeNode(
-                                        type = ComposeType.Text,
-                                        properties = NodeProperties.TextProps(
-                                            text = "Second text on lazy row"
-                                        ),
-                                    ),
-                                    ComposeNode(
-                                        type = ComposeType.Text,
-                                        properties = NodeProperties.TextProps(
-                                            text = "Third text on lazy row"
-                                        ),
-                                    ),
-                                    ComposeNode(
-                                        type = ComposeType.Text,
-                                        properties = NodeProperties.TextProps(
-                                            text = "Fourth text on lazy row"
-                                        ),
-                                    ),
-                                ),
-                            ),
-                        ),
-                        ComposeNode(
-                            type = ComposeType.Card,
-                            composeModifier = ComposeModifier(
-                                operations = listOf(
-                                    ComposeModifier.Operation.FillMaxWidth,
-                                    ComposeModifier.Operation.Padding(8),
-                                )
-                            ),
-                            properties = NodeProperties.CardProps(
-                                elevation = 4,
-                                cornerRadius = 12,
-                                child = ComposeNode(
-                                    type = ComposeType.Column,
-                                    properties = NodeProperties.ColumnProps(
-                                        children = listOf(
-                                            ComposeNode(
-                                                type = ComposeType.Text,
-                                                properties = NodeProperties.TextProps(
-                                                    text = "Card Title"
-                                                ),
-                                                composeModifier = ComposeModifier(
-                                                    operations = listOf(
-                                                        ComposeModifier.Operation.Padding(16),
-                                                    )
-                                                ),
-                                            ),
-                                            ComposeNode(
-                                                type = ComposeType.Text,
-                                                properties = NodeProperties.TextProps(
-                                                    text = "Card body with elevation 4dp and 12dp rounded corners"
-                                                ),
-                                                composeModifier = ComposeModifier(
-                                                    operations = listOf(
-                                                        ComposeModifier.Operation.Padding(16),
-                                                    )
-                                                ),
-                                            ),
-                                        )
-                                    )
-                                )
-                            )
-                        ),
-                        ComposeNode(
-                            type = ComposeType.Button,
-                            properties = NodeProperties.ButtonProps(
-                                onClickEventName = "show_dialog",
-                                child = ComposeNode(
-                                    type = ComposeType.Text,
-                                    properties = NodeProperties.TextProps(
-                                        text = "Show Dialog"
-                                    )
-                                )
-                            )
-                        ),
-                        ComposeNode(
-                            type = ComposeType.AlertDialog,
-                            properties = NodeProperties.AlertDialogProps(
-                                title = ComposeNode(
-                                    type = ComposeType.Text,
-                                    properties = NodeProperties.TextProps(
-                                        text = "Confirm Action"
-                                    )
-                                ),
-                                text = ComposeNode(
-                                    type = ComposeType.Text,
-                                    properties = NodeProperties.TextProps(
-                                        text = "Do you want to proceed with this action?"
-                                    )
-                                ),
-                                confirmButton = ComposeNode(
-                                    type = ComposeType.Button,
-                                    properties = NodeProperties.ButtonProps(
-                                        onClickEventName = "dialog_confirm",
-                                        child = ComposeNode(
-                                            type = ComposeType.Text,
-                                            properties = NodeProperties.TextProps(
-                                                text = "Confirm"
-                                            )
-                                        )
-                                    )
-                                ),
-                                dismissButton = ComposeNode(
-                                    type = ComposeType.Button,
-                                    properties = NodeProperties.ButtonProps(
-                                        onClickEventName = "dialog_dismiss",
-                                        child = ComposeNode(
-                                            type = ComposeType.Text,
-                                            properties = NodeProperties.TextProps(
-                                                text = "Cancel"
-                                            )
-                                        )
-                                    )
-                                ),
-                                visibilityStateHostName = "dialog_visibility",
-                            )
-                        ),
-                        ComposeNode(
-                            type = ComposeType.TopAppBar,
-                            properties = NodeProperties.TopAppBarProps(
-                                title = ComposeNode(
-                                    type = ComposeType.Text,
-                                    properties = NodeProperties.TextProps(
-                                        text = "My App"
-                                    )
-                                ),
-                                navigationIcon = ComposeNode(
-                                    type = ComposeType.Button,
-                                    properties = NodeProperties.ButtonProps(
-                                        onClickEventName = "button_clicked",
-                                        child = ComposeNode(
-                                            type = ComposeType.Text,
-                                            properties = NodeProperties.TextProps(
-                                                text = "<"
-                                            )
-                                        )
-                                    )
-                                ),
-                                actions = listOf(
-                                    ComposeNode(
-                                        type = ComposeType.Button,
-                                        properties = NodeProperties.ButtonProps(
-                                            onClickEventName = "button_clicked",
-                                            child = ComposeNode(
-                                                type = ComposeType.Text,
-                                                properties = NodeProperties.TextProps(
-                                                    text = "Action"
-                                                )
-                                            )
-                                        )
-                                    ),
-                                ),
-                            )
-                        ),
-                        ComposeNode(
-                            type = ComposeType.BottomBar,
-                            properties = NodeProperties.BottomBarProps(
-                                children = listOf(
-                                    ComposeNode(
-                                        type = ComposeType.BottomNavigationItem,
-                                        properties = NodeProperties.BottomNavigationItemProps(
-                                            selected = true,
-                                            onClickEventName = "button_clicked",
-                                            label = ComposeNode(
-                                                type = ComposeType.Text,
-                                                properties = NodeProperties.TextProps(text = "Home"),
-                                            ),
-                                            icon = ComposeNode(
-                                                type = ComposeType.Text,
-                                                properties = NodeProperties.TextProps(text = "H"),
-                                            ),
-                                        )
-                                    ),
-                                    ComposeNode(
-                                        type = ComposeType.BottomNavigationItem,
-                                        properties = NodeProperties.BottomNavigationItemProps(
-                                            selected = false,
-                                            onClickEventName = "button_clicked",
-                                            label = ComposeNode(
-                                                type = ComposeType.Text,
-                                                properties = NodeProperties.TextProps(text = "Search"),
-                                            ),
-                                            icon = ComposeNode(
-                                                type = ComposeType.Text,
-                                                properties = NodeProperties.TextProps(text = "S"),
-                                            ),
-                                        )
-                                    ),
-                                    ComposeNode(
-                                        type = ComposeType.BottomNavigationItem,
-                                        properties = NodeProperties.BottomNavigationItemProps(
-                                            selected = false,
-                                            onClickEventName = "button_clicked",
-                                            label = ComposeNode(
-                                                type = ComposeType.Text,
-                                                properties = NodeProperties.TextProps(text = "Profile"),
-                                            ),
-                                            icon = ComposeNode(
-                                                type = ComposeType.Text,
-                                                properties = NodeProperties.TextProps(text = "P"),
-                                            ),
-                                        )
-                                    ),
-                                ),
-                            )
-                        ),
-                        ComposeNode(
-                            type = ComposeType.Scaffold,
-                            composeModifier = ComposeModifier(
-                                operations = listOf(
-                                    ComposeModifier.Operation.FillMaxWidth,
-                                    ComposeModifier.Operation.Height(180),
-                                )
-                            ),
-                            properties = NodeProperties.ScaffoldProps(
-                                topBar = ComposeNode(
-                                    type = ComposeType.TopAppBar,
-                                    properties = NodeProperties.TopAppBarProps(
-                                        title = ComposeNode(
-                                            type = ComposeType.Text,
-                                            properties = NodeProperties.TextProps(
-                                                text = "Scaffold App Bar"
-                                            )
-                                        )
-                                    )
-                                ),
-                                bottomBar = ComposeNode(
-                                    type = ComposeType.BottomBar,
-                                    properties = NodeProperties.BottomBarProps(
-                                        children = listOf(
-                                            ComposeNode(
-                                                type = ComposeType.BottomNavigationItem,
-                                                properties = NodeProperties.BottomNavigationItemProps(
-                                                    selected = true,
-                                                    label = ComposeNode(
-                                                        type = ComposeType.Text,
-                                                        properties = NodeProperties.TextProps(text = "Home"),
-                                                    ),
-                                                    icon = ComposeNode(
-                                                        type = ComposeType.Text,
-                                                        properties = NodeProperties.TextProps(text = "H"),
-                                                    ),
-                                                )
-                                            ),
-                                            ComposeNode(
-                                                type = ComposeType.BottomNavigationItem,
-                                                properties = NodeProperties.BottomNavigationItemProps(
-                                                    selected = false,
-                                                    label = ComposeNode(
-                                                        type = ComposeType.Text,
-                                                        properties = NodeProperties.TextProps(text = "Settings"),
-                                                    ),
-                                                    icon = ComposeNode(
-                                                        type = ComposeType.Text,
-                                                        properties = NodeProperties.TextProps(text = "S"),
-                                                    ),
-                                                )
-                                            ),
-                                        ),
-                                    )
-                                ),
-                                child = ComposeNode(
-                                    type = ComposeType.Text,
-                                    properties = NodeProperties.TextProps(
-                                        text = "Content inside Scaffold"
-                                    ),
-                                    composeModifier = ComposeModifier(
-                                        operations = listOf(
-                                            ComposeModifier.Operation.Padding(16),
-                                        )
-                                    ),
-                                )
-                            )
-                        ),
-                        ComposeNode(
-                            type = ComposeType.Custom,
-                            properties = NodeProperties.CustomProps(
-                                customType = "ProductCard",
-                                customData = buildJsonObject {
-                                    put("title", JsonPrimitive("Custom Product"))
-                                    put("price", JsonPrimitive("99.99"))
-                                }
-                            )
-                        ),
-                    )
-                )
-            )
-            // The ComposeNode tree can also be serialized to JSON with composeNode.toString()
-            // and deserialized back with jsonString.ToCompose().
-            // See the project documentation for the full JSON schema reference.
-            val composeAsString = composeNode.toString()
-            LazyColumn {
-                item {
-                    composeAsString.ToCompose()
-                }
-
-                item {
-                    Divider()
-                }
-
-                item {
-                    Text(text = composeAsString)
-                }
-            }
+            rootScaffold.ToCompose()
         }
     }
 }
@@ -654,4 +201,3 @@ fun CustomRenderersComposition(
         content()
     }
 }
-

--- a/composeApp/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/ShowcaseSections.kt
+++ b/composeApp/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/ShowcaseSections.kt
@@ -1,0 +1,701 @@
+package com.jesusdmedinac.compose.sdui
+
+import com.jesusdmedinac.jsontocompose.model.ComposeModifier
+import com.jesusdmedinac.jsontocompose.model.ComposeNode
+import com.jesusdmedinac.jsontocompose.model.ComposeShape
+import com.jesusdmedinac.jsontocompose.model.ComposeType
+import com.jesusdmedinac.jsontocompose.model.NodeProperties
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+
+// --- Section Builders ---
+
+fun sectionHeader(title: String): ComposeNode {
+    return ComposeNode(
+        type = ComposeType.Text,
+        properties = NodeProperties.TextProps(text = title),
+        composeModifier = ComposeModifier(
+            operations = listOf(
+                ComposeModifier.Operation.FillMaxWidth,
+                ComposeModifier.Operation.BackgroundColor("#EEEEEE"),
+                ComposeModifier.Operation.Padding(16),
+            )
+        )
+    )
+}
+
+fun layoutSection(): List<ComposeNode> {
+    return listOf(
+        sectionHeader("Layouts"),
+        ComposeNode(
+            type = ComposeType.Column,
+            composeModifier = ComposeModifier(
+                operations = listOf(
+                    ComposeModifier.Operation.Padding(16),
+                    ComposeModifier.Operation.FillMaxWidth
+                )
+            ),
+            properties = NodeProperties.ColumnProps(
+                verticalArrangement = "SpaceBetween",
+                horizontalAlignment = "CenterHorizontally",
+                children = listOf(
+                    ComposeNode(
+                        type = ComposeType.Text,
+                        properties = NodeProperties.TextProps(text = "Column Item 1"),
+                        composeModifier = ComposeModifier(operations = listOf(ComposeModifier.Operation.Padding(4)))
+                    ),
+                    ComposeNode(
+                        type = ComposeType.Text,
+                        properties = NodeProperties.TextProps(text = "Column Item 2"),
+                        composeModifier = ComposeModifier(operations = listOf(ComposeModifier.Operation.Padding(4)))
+                    ),
+                    ComposeNode(
+                        type = ComposeType.Text,
+                        properties = NodeProperties.TextProps(text = "Column Item 3"),
+                        composeModifier = ComposeModifier(operations = listOf(ComposeModifier.Operation.Padding(4)))
+                    )
+                )
+            )
+        ),
+        ComposeNode(
+            type = ComposeType.Row,
+            composeModifier = ComposeModifier(
+                operations = listOf(
+                    ComposeModifier.Operation.Padding(16),
+                    ComposeModifier.Operation.FillMaxWidth
+                )
+            ),
+            properties = NodeProperties.RowProps(
+                horizontalArrangement = "SpaceEvenly",
+                verticalAlignment = "CenterVertically",
+                children = listOf(
+                    ComposeNode(
+                        type = ComposeType.Text,
+                        properties = NodeProperties.TextProps(text = "Row 1"),
+                        composeModifier = ComposeModifier(operations = listOf(ComposeModifier.Operation.Padding(4)))
+                    ),
+                    ComposeNode(
+                        type = ComposeType.Text,
+                        properties = NodeProperties.TextProps(text = "Row 2"),
+                        composeModifier = ComposeModifier(operations = listOf(ComposeModifier.Operation.Padding(4)))
+                    ),
+                    ComposeNode(
+                        type = ComposeType.Text,
+                        properties = NodeProperties.TextProps(text = "Row 3"),
+                        composeModifier = ComposeModifier(operations = listOf(ComposeModifier.Operation.Padding(4)))
+                    )
+                )
+            )
+        ),
+        ComposeNode(
+            type = ComposeType.Box,
+            composeModifier = ComposeModifier(
+                operations = listOf(
+                    ComposeModifier.Operation.Padding(16),
+                    ComposeModifier.Operation.FillMaxWidth,
+                    ComposeModifier.Operation.Height(100),
+                    ComposeModifier.Operation.BackgroundColor("#E0E0E0")
+                )
+            ),
+            properties = NodeProperties.BoxProps(
+                contentAlignment = "Center",
+                children = listOf(
+                    ComposeNode(
+                        type = ComposeType.Text,
+                        properties = NodeProperties.TextProps(text = "Box Bottom Layer"),
+                        composeModifier = ComposeModifier(
+                            operations = listOf(
+                                ComposeModifier.Operation.Padding(16),
+                                ComposeModifier.Operation.BackgroundColor("#B0B0B0")
+                            )
+                        )
+                    ),
+                    ComposeNode(
+                        type = ComposeType.Text,
+                        properties = NodeProperties.TextProps(text = "Box Top Layer"),
+                        composeModifier = ComposeModifier(
+                            operations = listOf(
+                                ComposeModifier.Operation.Padding(8),
+                                ComposeModifier.Operation.BackgroundColor("#FFFFFF")
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    )
+}
+
+fun contentSection(): List<ComposeNode> {
+    return listOf(
+        sectionHeader("Content"),
+        ComposeNode(
+            type = ComposeType.Column,
+            composeModifier = ComposeModifier(operations = listOf(ComposeModifier.Operation.Padding(16))),
+            properties = NodeProperties.ColumnProps(
+                children = listOf(
+                    ComposeNode(
+                        type = ComposeType.Text,
+                        properties = NodeProperties.TextProps(text = "This is a styled Text component"),
+                        composeModifier = ComposeModifier(operations = listOf(ComposeModifier.Operation.Padding(8)))
+                    ),
+                    ComposeNode(
+                        type = ComposeType.Image,
+                        properties = NodeProperties.ImageProps(
+                            url = "https://relatos.jesusdmedinac.com/_astro/carta-al-lector.OLllKYCu_Z1cdMQV.webp",
+                            contentDescription = "Image from URL",
+                            contentScale = "Fit"
+                        ),
+                        composeModifier = ComposeModifier(
+                            operations = listOf(
+                                ComposeModifier.Operation.Height(150),
+                                ComposeModifier.Operation.FillMaxWidth,
+                                ComposeModifier.Operation.Padding(8)
+                            )
+                        )
+                    ),
+                    ComposeNode(
+                        type = ComposeType.Image,
+                        properties = NodeProperties.ImageProps(
+                            resourceName = "compose-multiplatform",
+                            contentDescription = "Image from Resource",
+                            contentScale = "Fit"
+                        ),
+                        composeModifier = ComposeModifier(
+                            operations = listOf(
+                                ComposeModifier.Operation.Height(100),
+                                ComposeModifier.Operation.FillMaxWidth,
+                                ComposeModifier.Operation.Padding(8)
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    )
+}
+
+fun inputSection(): List<ComposeNode> {
+    return listOf(
+        sectionHeader("Input"),
+        ComposeNode(
+            type = ComposeType.Column,
+            composeModifier = ComposeModifier(operations = listOf(ComposeModifier.Operation.Padding(16))),
+            properties = NodeProperties.ColumnProps(
+                children = listOf(
+                    ComposeNode(
+                        type = ComposeType.Button,
+                        properties = NodeProperties.ButtonProps(
+                            onClickEventName = "onButtonClick",
+                            child = ComposeNode(
+                                type = ComposeType.Text,
+                                properties = NodeProperties.TextProps(text = "Click Me")
+                            )
+                        ),
+                        composeModifier = ComposeModifier(operations = listOf(ComposeModifier.Operation.Padding(8)))
+                    ),
+                    // TextFieldProps does not have a 'label' property.
+                    // Adding a Text node above to simulate label.
+                    ComposeNode(
+                        type = ComposeType.Text,
+                        properties = NodeProperties.TextProps(text = "Enter text:"),
+                        composeModifier = ComposeModifier(operations = listOf(ComposeModifier.Operation.Padding(4)))
+                    ),
+                    ComposeNode(
+                        type = ComposeType.TextField,
+                        properties = NodeProperties.TextFieldProps(
+                            valueStateHostName = "text_field_value"
+                        ),
+                        composeModifier = ComposeModifier(
+                            operations = listOf(
+                                ComposeModifier.Operation.Padding(8),
+                                ComposeModifier.Operation.FillMaxWidth
+                            )
+                        )
+                    ),
+                    ComposeNode(
+                        type = ComposeType.Row,
+                        properties = NodeProperties.RowProps(
+                            verticalAlignment = "CenterVertically",
+                            children = listOf(
+                                ComposeNode(
+                                    type = ComposeType.Switch,
+                                    properties = NodeProperties.SwitchProps(
+                                        checkedStateHostName = "switch_state",
+                                        onCheckedChangeEventName = "onSwitchToggle",
+                                        enabledStateHostName = "switch_enabled"
+                                    )
+                                ),
+                                ComposeNode(
+                                    type = ComposeType.Text,
+                                    properties = NodeProperties.TextProps(text = "Toggle Switch"),
+                                    composeModifier = ComposeModifier(operations = listOf(ComposeModifier.Operation.Padding(8)))
+                                )
+                            )
+                        ),
+                        composeModifier = ComposeModifier(operations = listOf(ComposeModifier.Operation.Padding(8)))
+                    ),
+                    ComposeNode(
+                        type = ComposeType.Row,
+                        properties = NodeProperties.RowProps(
+                            verticalAlignment = "CenterVertically",
+                            children = listOf(
+                                ComposeNode(
+                                    type = ComposeType.Checkbox,
+                                    properties = NodeProperties.CheckboxProps(
+                                        checkedStateHostName = "checkbox_state",
+                                        onCheckedChangeEventName = "onCheckboxToggle",
+                                        enabledStateHostName = "checkbox_enabled"
+                                    )
+                                ),
+                                ComposeNode(
+                                    type = ComposeType.Text,
+                                    properties = NodeProperties.TextProps(text = "Check Box"),
+                                    composeModifier = ComposeModifier(operations = listOf(ComposeModifier.Operation.Padding(8)))
+                                )
+                            )
+                        ),
+                        composeModifier = ComposeModifier(operations = listOf(ComposeModifier.Operation.Padding(8)))
+                    )
+                )
+            )
+        )
+    )
+}
+
+fun containerSection(): List<ComposeNode> {
+    return listOf(
+        sectionHeader("Containers"),
+        ComposeNode(
+            type = ComposeType.Column,
+            composeModifier = ComposeModifier(operations = listOf(ComposeModifier.Operation.Padding(16))),
+            properties = NodeProperties.ColumnProps(
+                children = listOf(
+                    ComposeNode(
+                        type = ComposeType.Card,
+                        composeModifier = ComposeModifier(
+                            operations = listOf(
+                                ComposeModifier.Operation.FillMaxWidth,
+                                ComposeModifier.Operation.Padding(8)
+                            )
+                        ),
+                        properties = NodeProperties.CardProps(
+                            elevation = 4,
+                            cornerRadius = 8,
+                            child = ComposeNode(
+                                type = ComposeType.Column,
+                                composeModifier = ComposeModifier(operations = listOf(ComposeModifier.Operation.Padding(16))),
+                                properties = NodeProperties.ColumnProps(
+                                    children = listOf(
+                                        ComposeNode(
+                                            type = ComposeType.Text,
+                                            properties = NodeProperties.TextProps(text = "Card Title")
+                                        ),
+                                        ComposeNode(
+                                            type = ComposeType.Text,
+                                            properties = NodeProperties.TextProps(text = "Card Content with elevation and rounded corners.")
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    // Mini Scaffold
+                    ComposeNode(
+                        type = ComposeType.Scaffold,
+                        composeModifier = ComposeModifier(
+                            operations = listOf(
+                                ComposeModifier.Operation.FillMaxWidth,
+                                ComposeModifier.Operation.Height(150),
+                                ComposeModifier.Operation.Padding(8),
+                                ComposeModifier.Operation.Border(1, "#CCCCCC", ComposeShape.Rectangle)
+                            )
+                        ),
+                        properties = NodeProperties.ScaffoldProps(
+                            topBar = ComposeNode(
+                                type = ComposeType.TopAppBar,
+                                properties = NodeProperties.TopAppBarProps(
+                                    title = ComposeNode(
+                                        type = ComposeType.Text,
+                                        properties = NodeProperties.TextProps(text = "Mini Scaffold")
+                                    )
+                                )
+                            ),
+                            child = ComposeNode(
+                                type = ComposeType.Box,
+                                properties = NodeProperties.BoxProps(
+                                    contentAlignment = "Center",
+                                    children = listOf(
+                                        ComposeNode(
+                                            type = ComposeType.Text,
+                                            properties = NodeProperties.TextProps(text = "Scaffold Body")
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    ComposeNode(
+                        type = ComposeType.Button,
+                        properties = NodeProperties.ButtonProps(
+                            onClickEventName = "onShowDialog",
+                            child = ComposeNode(
+                                type = ComposeType.Text,
+                                properties = NodeProperties.TextProps(text = "Show Alert Dialog")
+                            )
+                        ),
+                        composeModifier = ComposeModifier(operations = listOf(ComposeModifier.Operation.Padding(8)))
+                    ),
+                    ComposeNode(
+                        type = ComposeType.AlertDialog,
+                        properties = NodeProperties.AlertDialogProps(
+                            visibilityStateHostName = "dialog_visible",
+                            title = ComposeNode(
+                                type = ComposeType.Text,
+                                properties = NodeProperties.TextProps(text = "Alert")
+                            ),
+                            text = ComposeNode(
+                                type = ComposeType.Text,
+                                properties = NodeProperties.TextProps(text = "This is a demo dialog.")
+                            ),
+                            confirmButton = ComposeNode(
+                                type = ComposeType.Button,
+                                properties = NodeProperties.ButtonProps(
+                                    onClickEventName = "onDialogConfirm",
+                                    child = ComposeNode(
+                                        type = ComposeType.Text,
+                                        properties = NodeProperties.TextProps(text = "OK")
+                                    )
+                                )
+                            ),
+                            dismissButton = ComposeNode(
+                                type = ComposeType.Button,
+                                properties = NodeProperties.ButtonProps(
+                                    onClickEventName = "onDialogDismiss",
+                                    child = ComposeNode(
+                                        type = ComposeType.Text,
+                                        properties = NodeProperties.TextProps(text = "Cancel")
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    )
+}
+
+fun navigationSection(): List<ComposeNode> {
+    return listOf(
+        sectionHeader("Navigation"),
+        ComposeNode(
+            type = ComposeType.Column,
+            composeModifier = ComposeModifier(operations = listOf(ComposeModifier.Operation.Padding(16))),
+            properties = NodeProperties.ColumnProps(
+                children = listOf(
+                    ComposeNode(
+                        type = ComposeType.TopAppBar,
+                        properties = NodeProperties.TopAppBarProps(
+                            title = ComposeNode(
+                                type = ComposeType.Text,
+                                properties = NodeProperties.TextProps(text = "Top App Bar Demo")
+                            ),
+                            navigationIcon = ComposeNode(
+                                type = ComposeType.Button,
+                                properties = NodeProperties.ButtonProps(
+                                    onClickEventName = "onButtonClick",
+                                    child = ComposeNode(
+                                        type = ComposeType.Text,
+                                        properties = NodeProperties.TextProps(text = "Menu")
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    ComposeNode(
+                        type = ComposeType.Box,
+                        composeModifier = ComposeModifier(operations = listOf(ComposeModifier.Operation.Height(16))),
+                        properties = NodeProperties.BoxProps()
+                    ),
+                    ComposeNode(
+                        type = ComposeType.BottomBar,
+                        properties = NodeProperties.BottomBarProps(
+                            children = listOf(
+                                ComposeNode(
+                                    type = ComposeType.BottomNavigationItem,
+                                    properties = NodeProperties.BottomNavigationItemProps(
+                                        selected = true,
+                                        label = ComposeNode(
+                                            type = ComposeType.Text,
+                                            properties = NodeProperties.TextProps(text = "Item 1")
+                                        ),
+                                        icon = ComposeNode(
+                                            type = ComposeType.Text,
+                                            properties = NodeProperties.TextProps(text = "1")
+                                        )
+                                    )
+                                ),
+                                ComposeNode(
+                                    type = ComposeType.BottomNavigationItem,
+                                    properties = NodeProperties.BottomNavigationItemProps(
+                                        selected = false,
+                                        label = ComposeNode(
+                                            type = ComposeType.Text,
+                                            properties = NodeProperties.TextProps(text = "Item 2")
+                                        ),
+                                        icon = ComposeNode(
+                                            type = ComposeType.Text,
+                                            properties = NodeProperties.TextProps(text = "2")
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    )
+}
+
+fun lazyListSection(): List<ComposeNode> {
+    return listOf(
+        sectionHeader("Lazy Lists"),
+        ComposeNode(
+            type = ComposeType.Column,
+            composeModifier = ComposeModifier(operations = listOf(ComposeModifier.Operation.Padding(16))),
+            properties = NodeProperties.ColumnProps(
+                children = listOf(
+                    ComposeNode(
+                        type = ComposeType.Text,
+                        properties = NodeProperties.TextProps(text = "Lazy Row:"),
+                        // Fixed Padding usage: only value constructor available
+                        composeModifier = ComposeModifier(operations = listOf(ComposeModifier.Operation.Padding(8)))
+                    ),
+                    ComposeNode(
+                        type = ComposeType.LazyRow,
+                        composeModifier = ComposeModifier(
+                            operations = listOf(
+                                ComposeModifier.Operation.FillMaxWidth,
+                                ComposeModifier.Operation.Height(60) // Fixed height to prevent crash
+                            )
+                        ),
+                        properties = NodeProperties.RowProps(
+                            children = (1..10).map { i ->
+                                ComposeNode(
+                                    type = ComposeType.Box,
+                                    composeModifier = ComposeModifier(
+                                        operations = listOf(
+                                            ComposeModifier.Operation.Width(100),
+                                            ComposeModifier.Operation.Height(50),
+                                            ComposeModifier.Operation.Padding(4),
+                                            ComposeModifier.Operation.BackgroundColor("#DDDDDD"),
+                                            ComposeModifier.Operation.Border(1, "#000000", ComposeShape.Rectangle)
+                                        )
+                                    ),
+                                    properties = NodeProperties.BoxProps(
+                                        contentAlignment = "Center",
+                                        children = listOf(
+                                            ComposeNode(
+                                                type = ComposeType.Text,
+                                                properties = NodeProperties.TextProps(text = "Item $i")
+                                            )
+                                        )
+                                    )
+                                )
+                            }
+                        )
+                    ),
+                    ComposeNode(
+                        type = ComposeType.Text,
+                        properties = NodeProperties.TextProps(text = "Lazy Column (Nested with Fixed Height):"),
+                        // Fixed Padding usage
+                        composeModifier = ComposeModifier(
+                            operations = listOf(
+                                ComposeModifier.Operation.Padding(16)
+                            )
+                        )
+                    ),
+                    ComposeNode(
+                        type = ComposeType.LazyColumn,
+                        composeModifier = ComposeModifier(
+                            operations = listOf(
+                                ComposeModifier.Operation.FillMaxWidth,
+                                ComposeModifier.Operation.Height(150), // Fixed height to prevent crash
+                                ComposeModifier.Operation.Border(1, "#999999", ComposeShape.Rectangle)
+                            )
+                        ),
+                        properties = NodeProperties.ColumnProps(
+                            children = (1..10).map { i ->
+                                ComposeNode(
+                                    type = ComposeType.Text,
+                                    properties = NodeProperties.TextProps(text = "List Item $i"),
+                                    composeModifier = ComposeModifier(
+                                        operations = listOf(
+                                            ComposeModifier.Operation.Padding(8),
+                                            ComposeModifier.Operation.FillMaxWidth
+                                        )
+                                    )
+                                )
+                            }
+                        )
+                    )
+                )
+            )
+        )
+    )
+}
+
+fun modifiersSection(): List<ComposeNode> {
+    return listOf(
+        sectionHeader("Modifiers"),
+        ComposeNode(
+            type = ComposeType.Column,
+            composeModifier = ComposeModifier(operations = listOf(ComposeModifier.Operation.Padding(16))),
+            properties = NodeProperties.ColumnProps(
+                children = listOf(
+                    modifierExample("Padding (16dp)",
+                        ComposeModifier(operations = listOf(
+                            ComposeModifier.Operation.BackgroundColor("#FFCCBC"),
+                            ComposeModifier.Operation.Padding(16),
+                            ComposeModifier.Operation.BackgroundColor("#FF5722")
+                        ))
+                    ),
+                    modifierExample("Width (150dp) & Height (50dp)",
+                        ComposeModifier(operations = listOf(
+                            ComposeModifier.Operation.Width(150),
+                            ComposeModifier.Operation.Height(50),
+                            ComposeModifier.Operation.BackgroundColor("#8BC34A")
+                        ))
+                    ),
+                    modifierExample("Border (2dp Blue)",
+                        ComposeModifier(operations = listOf(
+                            ComposeModifier.Operation.Padding(8),
+                            ComposeModifier.Operation.Border(2, "#2196F3", ComposeShape.Rectangle),
+                            ComposeModifier.Operation.Padding(8)
+                        ))
+                    ),
+                    modifierExample("Rounded Corners (16dp)",
+                        ComposeModifier(operations = listOf(
+                            ComposeModifier.Operation.Width(100),
+                            ComposeModifier.Operation.Height(50),
+                            ComposeModifier.Operation.Clip(ComposeShape.RoundedCorner(all = 16)),
+                            ComposeModifier.Operation.BackgroundColor("#9C27B0")
+                        ))
+                    ),
+                    modifierExample("Circle Shape",
+                        ComposeModifier(operations = listOf(
+                            ComposeModifier.Operation.Width(60),
+                            ComposeModifier.Operation.Height(60),
+                            ComposeModifier.Operation.Clip(ComposeShape.Circle),
+                            ComposeModifier.Operation.BackgroundColor("#E91E63")
+                        ))
+                    ),
+                    modifierExample("Shadow (Elevation 8dp)",
+                        ComposeModifier(operations = listOf(
+                            ComposeModifier.Operation.Padding(8),
+                            ComposeModifier.Operation.Shadow(8, ComposeShape.Rectangle),
+                            ComposeModifier.Operation.BackgroundColor("#FFFFFF"),
+                            ComposeModifier.Operation.Padding(16)
+                        ))
+                    ),
+                    modifierExample("Alpha (0.5)",
+                        ComposeModifier(operations = listOf(
+                            ComposeModifier.Operation.Width(100),
+                            ComposeModifier.Operation.Height(50),
+                            ComposeModifier.Operation.BackgroundColor("#000000"),
+                            ComposeModifier.Operation.Alpha(0.5f)
+                        ))
+                    ),
+                    modifierExample("Rotate (45 deg)",
+                        ComposeModifier(operations = listOf(
+                            ComposeModifier.Operation.Width(50),
+                            ComposeModifier.Operation.Height(50),
+                            ComposeModifier.Operation.Rotate(45f),
+                            ComposeModifier.Operation.BackgroundColor("#FFC107")
+                        ))
+                    ),
+                    // FillMaxSize example wrapped in a fixed-size Box
+                    ComposeNode(
+                        type = ComposeType.Text,
+                        properties = NodeProperties.TextProps(text = "FillMaxSize (inside 100x100 Box)"),
+                        // Fixed Padding usage
+                        composeModifier = ComposeModifier(operations = listOf(ComposeModifier.Operation.Padding(8)))
+                    ),
+                    ComposeNode(
+                        type = ComposeType.Box,
+                        composeModifier = ComposeModifier(operations = listOf(
+                            ComposeModifier.Operation.Width(100),
+                            ComposeModifier.Operation.Height(100),
+                            ComposeModifier.Operation.Border(1, "#000000", ComposeShape.Rectangle)
+                        )),
+                        properties = NodeProperties.BoxProps(
+                            children = listOf(
+                                ComposeNode(
+                                    type = ComposeType.Box,
+                                    composeModifier = ComposeModifier(operations = listOf(
+                                        ComposeModifier.Operation.FillMaxSize,
+                                        ComposeModifier.Operation.BackgroundColor("#00BCD4")
+                                    )),
+                                    properties = NodeProperties.BoxProps()
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    )
+}
+
+fun modifierExample(label: String, modifier: ComposeModifier): ComposeNode {
+    return ComposeNode(
+        type = ComposeType.Column,
+        // Fixed Padding usage
+        composeModifier = ComposeModifier(operations = listOf(ComposeModifier.Operation.Padding(12))),
+        properties = NodeProperties.ColumnProps(
+            children = listOf(
+                ComposeNode(
+                    type = ComposeType.Text,
+                    properties = NodeProperties.TextProps(text = label),
+                    // Fixed Padding usage
+                    composeModifier = ComposeModifier(operations = listOf(ComposeModifier.Operation.Padding(4)))
+                ),
+                ComposeNode(
+                    type = ComposeType.Box,
+                    composeModifier = modifier,
+                    properties = NodeProperties.BoxProps(
+                        children = listOf(
+                             // Empty box content or minimal text to show the modifier effect
+                        )
+                    )
+                )
+            )
+        )
+    )
+}
+
+fun customSection(): List<ComposeNode> {
+    return listOf(
+        sectionHeader("Custom Components"),
+        ComposeNode(
+            type = ComposeType.Column,
+            composeModifier = ComposeModifier(operations = listOf(ComposeModifier.Operation.Padding(16))),
+            properties = NodeProperties.ColumnProps(
+                children = listOf(
+                    ComposeNode(
+                        type = ComposeType.Custom,
+                        properties = NodeProperties.CustomProps(
+                            customType = "ProductCard",
+                            customData = buildJsonObject {
+                                put("title", JsonPrimitive("Super Widget"))
+                                put("price", JsonPrimitive("19.99"))
+                            }
+                        )
+                    )
+                )
+            )
+        )
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/ShowcaseState.kt
+++ b/composeApp/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/ShowcaseState.kt
@@ -1,0 +1,106 @@
+package com.jesusdmedinac.compose.sdui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import com.jesusdmedinac.jsontocompose.behavior.Behavior
+import com.jesusdmedinac.jsontocompose.com.jesusdmedinac.jsontocompose.state.MutableStateHost
+import com.jesusdmedinac.jsontocompose.com.jesusdmedinac.jsontocompose.state.StateHost
+
+data class ShowcaseState(
+    val stateHosts: Map<String, StateHost<*>>,
+    val behaviors: Map<String, Behavior>
+)
+
+@Composable
+fun rememberShowcaseState(): ShowcaseState {
+    // Interactive StateHosts
+    val textFieldHost = remember { MutableStateHost("") }
+    val switchStateHost = remember { MutableStateHost(false) }
+    val checkboxStateHost = remember { MutableStateHost(false) }
+    val dialogVisibleHost = remember { MutableStateHost(false) }
+    val switchEnabledHost = remember { MutableStateHost(true) }
+    val checkboxEnabledHost = remember { MutableStateHost(true) }
+
+    // BottomBar Selection StateHosts
+    val navHomeSelected = remember { MutableStateHost(true) }
+    val navSearchSelected = remember { MutableStateHost(false) }
+    val navProfileSelected = remember { MutableStateHost(false) }
+
+    val behaviors = remember {
+        mapOf(
+            // Interactive Components
+            "onButtonClick" to object : Behavior {
+                override fun invoke() {
+                    println("Button Clicked")
+                }
+            },
+            "onSwitchToggle" to object : Behavior {
+                override fun invoke() {
+                    println("Switch Toggled: ${switchStateHost.state}")
+                }
+            },
+            "onCheckboxToggle" to object : Behavior {
+                override fun invoke() {
+                    println("Checkbox Toggled: ${checkboxStateHost.state}")
+                }
+            },
+            "onShowDialog" to object : Behavior {
+                override fun invoke() {
+                    dialogVisibleHost.onStateChange(true)
+                }
+            },
+            "onDialogConfirm" to object : Behavior {
+                override fun invoke() {
+                    println("Dialog Confirmed")
+                    dialogVisibleHost.onStateChange(false)
+                }
+            },
+            "onDialogDismiss" to object : Behavior {
+                override fun invoke() {
+                    println("Dialog Dismissed")
+                    dialogVisibleHost.onStateChange(false)
+                }
+            },
+            // Navigation Mutual Exclusion
+            "onNavHome" to object : Behavior {
+                override fun invoke() {
+                    navHomeSelected.onStateChange(true)
+                    navSearchSelected.onStateChange(false)
+                    navProfileSelected.onStateChange(false)
+                }
+            },
+            "onNavSearch" to object : Behavior {
+                override fun invoke() {
+                    navHomeSelected.onStateChange(false)
+                    navSearchSelected.onStateChange(true)
+                    navProfileSelected.onStateChange(false)
+                }
+            },
+            "onNavProfile" to object : Behavior {
+                override fun invoke() {
+                    navHomeSelected.onStateChange(false)
+                    navSearchSelected.onStateChange(false)
+                    navProfileSelected.onStateChange(true)
+                }
+            }
+        )
+    }
+
+    val stateHosts = remember {
+        mapOf<String, StateHost<*>>(
+            "text_field_value" to textFieldHost,
+            "switch_state" to switchStateHost,
+            "checkbox_state" to checkboxStateHost,
+            "dialog_visible" to dialogVisibleHost,
+            "switch_enabled" to switchEnabledHost,
+            "checkbox_enabled" to checkboxEnabledHost,
+            "nav_home_selected" to navHomeSelected,
+            "nav_search_selected" to navSearchSelected,
+            "nav_profile_selected" to navProfileSelected
+        )
+    }
+
+    return remember(stateHosts, behaviors) {
+        ShowcaseState(stateHosts, behaviors)
+    }
+}


### PR DESCRIPTION
Implemented the Demo App Showcase feature for the json-to-compose library.

Key changes:
- **Refactored App.kt**: Moved logic into a clean architecture.
- **Added ShowcaseState.kt**: Encapsulates state management (StateHosts, Behaviors) in a reusable composable `rememberShowcaseState()`.
- **Added ShowcaseSections.kt**: Contains pure functions to build the `ComposeNode` tree for each section (Layouts, Content, Input, etc.).
- **Component Catalog**: Implemented comprehensive examples for all supported components (Column, Row, Box, Text, Image, Button, TextField, Switch, Checkbox, Card, Scaffold, AlertDialog, TopAppBar, BottomBar, LazyColumn, LazyRow, Custom).
- **Modifier Showcase**: Added visual examples for all modifier operations (Padding, Border, Shadow, Clip, Alpha, Rotate, etc.).
- **Navigation Demo**: Implemented interactive BottomBar navigation using mutual exclusion behaviors.

This structure allows for easy expansion of the catalog and serves as a robust example of how to use the library in a real-world scenario.

---
*PR created automatically by Jules for task [1179665124990845412](https://jules.google.com/task/1179665124990845412) started by @jesusdmedinac*