### PR TITLE
feat: Skeleton Bootstrap for Phase 3

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -13,11 +13,11 @@
 | 1   | [phase-1-solidify-library](#1-phase-1-solidify-library)           | `library/`    | 187       | 187       | **100%** |
 | 2   | [phase-actions-system](#2-phase-actions-system)                   | `library/`    | 37        | 37        | **100%** |
 | 3   | [phase-demo-showcase](#3-phase-demo-showcase)                     | `composeApp/` | 36        | 36        | **100%** |
-| 4   | [phase-3-expand-library](#4-phase-3-expand-library)               | `library/`    | 239       | 78        | **33%**  |
+| 4   | [phase-3-expand-library](#4-phase-3-expand-library)               | `library/`    | 239       | 81        | **34%**  |
 | 5   | [phase-2-editor-mvp](#5-phase-2-editor-mvp)                       | `composy/`    | 54        | 0         | **0%**   |
 | 6   | [phase-4-semantics-testability](#6-phase-4-semantics-testability) | `library/`    | 26        | 0         | **0%**   |
 | 7   | [phase-3-differentiators](#7-phase-3-differentiators)             | Multi-module  | 37        | 0         | **0%**   |
-|     | **TOTAL**                                                         |               | **616**   | **338**   | **55%**  |
+|     | **TOTAL**                                                         |               | **616**   | **341**   | **55%**  |
 
 ```
 Progress: [██████████████████████░░░░░░░░░░░░░░░░░░] 55%
@@ -45,7 +45,7 @@ phase-3-expand-library ← IN PROGRESS
 
 ### 1. phase-3-expand-library
 
-**Status:** 🏗️ In Progress (78/239 — 33%)
+**Status:** 🏗️ In Progress (81/239 — 34%)
 **Module:** `library/`
 **Depends on:** phase-1 ✅, phase-actions-system ✅
 
@@ -60,7 +60,7 @@ phase-3-expand-library ← IN PROGRESS
 **Features:**
 | Feature | Scenarios | What it adds | Status |
 |---------|-----------|--------------|--------|
-| Skeleton Bootstrap | 3 | Base enum, properties and router switches for parallel work | 🔜 Pending |
+| Skeleton Bootstrap | 3 | Base enum, properties and router switches for parallel work | ✅ Done |
 | Text Enhancement | 18 | fontSize, fontWeight, color, textAlign, maxLines, overflow, etc. | ✅ Done |
 | Button Variants | 14 | OutlinedButton, TextButton, ElevatedButton, FilledTonalButton, IconButton, FAB | ✅ Done |
 | Card Variants | 8 | ElevatedCard, OutlinedCard | ✅ Done |

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/EditNodeScreenModel.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/EditNodeScreenModel.kt
@@ -81,6 +81,23 @@ class EditNodeScreenModel : ScreenModel, EditNodeBehavior {
                 ModifierOperation.Background -> ComposeModifier.Operation.Background("#FFFFFFFF", ComposeShape.Rectangle)
                 ModifierOperation.Alpha -> ComposeModifier.Operation.Alpha(1f)
                 ModifierOperation.Rotate -> ComposeModifier.Operation.Rotate(0f)
+                // --- Phase 3 modifiers ---
+                ModifierOperation.Clickable -> ComposeModifier.Operation.Clickable()
+                ModifierOperation.Weight -> ComposeModifier.Operation.Weight(1f)
+                ModifierOperation.VerticalScroll -> ComposeModifier.Operation.VerticalScroll
+                ModifierOperation.HorizontalScroll -> ComposeModifier.Operation.HorizontalScroll
+                ModifierOperation.Offset -> ComposeModifier.Operation.Offset(0, 0)
+                ModifierOperation.Size -> ComposeModifier.Operation.Size(0, 0)
+                ModifierOperation.WrapContentWidth -> ComposeModifier.Operation.WrapContentWidth
+                ModifierOperation.WrapContentHeight -> ComposeModifier.Operation.WrapContentHeight
+                ModifierOperation.AspectRatio -> ComposeModifier.Operation.AspectRatio(1f)
+                ModifierOperation.ZIndex -> ComposeModifier.Operation.ZIndex(0f)
+                ModifierOperation.MinWidth -> ComposeModifier.Operation.MinWidth(0)
+                ModifierOperation.MinHeight -> ComposeModifier.Operation.MinHeight(0)
+                ModifierOperation.MaxWidth -> ComposeModifier.Operation.MaxWidth(0)
+                ModifierOperation.MaxHeight -> ComposeModifier.Operation.MaxHeight(0)
+                ModifierOperation.AnimateContentSize -> ComposeModifier.Operation.AnimateContentSize
+                ModifierOperation.TestTag -> ComposeModifier.Operation.TestTag("")
             }
             val editingComposeNode = state.editingComposeNode?.copy(
                 composeModifier = state.editingComposeNode.composeModifier.copy(

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/ui/composable/ComposeComponents.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/ui/composable/ComposeComponents.kt
@@ -60,6 +60,7 @@ import com.composables.icons.lucide.Rows3
 import com.composables.icons.lucide.Rows4
 import com.composables.icons.lucide.Search
 import com.composables.icons.lucide.SeparatorHorizontal
+import com.composables.icons.lucide.SeparatorVertical
 import com.composables.icons.lucide.Smile
 import com.composables.icons.lucide.Square
 import com.composables.icons.lucide.SquareCheck

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/ui/composable/ComposeComponents.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/ui/composable/ComposeComponents.kt
@@ -205,6 +205,35 @@ fun ComposeComponent(
                 ComposeType.TabRow -> Lucide.Columns3
                 ComposeType.ScrollableTabRow -> Lucide.Columns4
                 ComposeType.Tab -> Lucide.Square
+                // --- Phase 3 stub icons ---
+                ComposeType.Slider -> Lucide.SeparatorHorizontal
+                ComposeType.RadioButton -> Lucide.Circle
+                ComposeType.SingleChoiceSegmentedButtonRow -> Lucide.Columns3
+                ComposeType.MultiChoiceSegmentedButtonRow -> Lucide.Columns3
+                ComposeType.SegmentedButton -> Lucide.Square
+                ComposeType.DatePicker -> Lucide.Square
+                ComposeType.TimePicker -> Lucide.Square
+                ComposeType.SearchBar -> Lucide.Search
+                ComposeType.HorizontalDivider -> Lucide.SeparatorHorizontal
+                ComposeType.VerticalDivider -> Lucide.SeparatorHorizontal
+                ComposeType.FlowRow -> Lucide.Columns3
+                ComposeType.FlowColumn -> Lucide.Rows3
+                ComposeType.Surface -> Lucide.Square
+                ComposeType.HorizontalPager -> Lucide.Columns4
+                ComposeType.VerticalPager -> Lucide.Rows4
+                ComposeType.ModalBottomSheet -> Lucide.PanelBottom
+                ComposeType.Badge -> Lucide.Circle
+                ComposeType.BadgedBox -> Lucide.Box
+                ComposeType.AssistChip -> Lucide.RectangleHorizontal
+                ComposeType.FilterChip -> Lucide.RectangleHorizontal
+                ComposeType.InputChip -> Lucide.RectangleHorizontal
+                ComposeType.SuggestionChip -> Lucide.RectangleHorizontal
+                ComposeType.CircularProgressIndicator -> Lucide.Circle
+                ComposeType.LinearProgressIndicator -> Lucide.SeparatorHorizontal
+                ComposeType.PlainTooltip -> Lucide.MessageSquare
+                ComposeType.RichTooltip -> Lucide.MessageSquare
+                ComposeType.SnackbarHost -> Lucide.PanelBottom
+                ComposeType.ListItem -> Lucide.Rows3
             },
             contentDescription = type.name
         )

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/ui/composable/ComposeComponents.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/ui/composable/ComposeComponents.kt
@@ -215,7 +215,7 @@ fun ComposeComponent(
                 ComposeType.TimePicker -> Lucide.Square
                 ComposeType.SearchBar -> Lucide.Search
                 ComposeType.HorizontalDivider -> Lucide.SeparatorHorizontal
-                ComposeType.VerticalDivider -> Lucide.SeparatorHorizontal
+                ComposeType.VerticalDivider -> Lucide.SeparatorVertical
                 ComposeType.FlowRow -> Lucide.Columns3
                 ComposeType.FlowColumn -> Lucide.Rows3
                 ComposeType.Surface -> Lucide.Square

--- a/docs/projects/phase-3-expand-library/PROGRESS.md
+++ b/docs/projects/phase-3-expand-library/PROGRESS.md
@@ -2,9 +2,9 @@
 
 ## Feature: Skeleton Bootstrap for Phase 3
 
-- [ ] Scenario: Scaffold pending Component Types
-- [ ] Scenario: Scaffold pending Modifier Operations
-- [ ] Scenario: Wire the main Router
+- [x] Scenario: Scaffold pending Component Types
+- [x] Scenario: Scaffold pending Modifier Operations
+- [x] Scenario: Wire the main Router
 
 ## Feature: Text Component Property Enhancement
 

--- a/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/JsonToCompose.kt
+++ b/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/JsonToCompose.kt
@@ -8,39 +8,67 @@ import com.jesusdmedinac.jsontocompose.behavior.Behavior
 import com.jesusdmedinac.jsontocompose.model.ComposeNode
 import com.jesusdmedinac.jsontocompose.model.ComposeType
 import com.jesusdmedinac.jsontocompose.renderer.ToAlertDialog
+import com.jesusdmedinac.jsontocompose.renderer.ToAssistChip
+import com.jesusdmedinac.jsontocompose.renderer.ToBadge
+import com.jesusdmedinac.jsontocompose.renderer.ToBadgedBox
 import com.jesusdmedinac.jsontocompose.renderer.ToBottomBar
 import com.jesusdmedinac.jsontocompose.renderer.ToBottomNavigationItem
 import com.jesusdmedinac.jsontocompose.renderer.ToBox
 import com.jesusdmedinac.jsontocompose.renderer.ToButton
 import com.jesusdmedinac.jsontocompose.renderer.ToCard
 import com.jesusdmedinac.jsontocompose.renderer.ToCheckbox
+import com.jesusdmedinac.jsontocompose.renderer.ToCircularProgressIndicator
 import com.jesusdmedinac.jsontocompose.renderer.ToColumn
 import com.jesusdmedinac.jsontocompose.renderer.ToCustom
+import com.jesusdmedinac.jsontocompose.renderer.ToDatePicker
 import com.jesusdmedinac.jsontocompose.renderer.ToElevatedCard
 import com.jesusdmedinac.jsontocompose.renderer.ToExtendedFloatingActionButton
+import com.jesusdmedinac.jsontocompose.renderer.ToFilterChip
 import com.jesusdmedinac.jsontocompose.renderer.ToFloatingActionButton
+import com.jesusdmedinac.jsontocompose.renderer.ToFlowColumn
+import com.jesusdmedinac.jsontocompose.renderer.ToFlowRow
+import com.jesusdmedinac.jsontocompose.renderer.ToHorizontalDivider
+import com.jesusdmedinac.jsontocompose.renderer.ToHorizontalPager
 import com.jesusdmedinac.jsontocompose.renderer.ToIcon
 import com.jesusdmedinac.jsontocompose.renderer.ToIconButton
 import com.jesusdmedinac.jsontocompose.renderer.ToImage
+import com.jesusdmedinac.jsontocompose.renderer.ToInputChip
 import com.jesusdmedinac.jsontocompose.renderer.ToLazyColumn
 import com.jesusdmedinac.jsontocompose.renderer.ToLazyRow
+import com.jesusdmedinac.jsontocompose.renderer.ToLinearProgressIndicator
+import com.jesusdmedinac.jsontocompose.renderer.ToListItem
+import com.jesusdmedinac.jsontocompose.renderer.ToModalBottomSheet
 import com.jesusdmedinac.jsontocompose.renderer.ToModalNavigationDrawer
+import com.jesusdmedinac.jsontocompose.renderer.ToMultiChoiceSegmentedButtonRow
 import com.jesusdmedinac.jsontocompose.renderer.ToNavigationBar
 import com.jesusdmedinac.jsontocompose.renderer.ToNavigationBarItem
 import com.jesusdmedinac.jsontocompose.renderer.ToNavigationDrawerItem
 import com.jesusdmedinac.jsontocompose.renderer.ToNavigationRail
 import com.jesusdmedinac.jsontocompose.renderer.ToNavigationRailItem
 import com.jesusdmedinac.jsontocompose.renderer.ToOutlinedCard
+import com.jesusdmedinac.jsontocompose.renderer.ToPlainTooltip
+import com.jesusdmedinac.jsontocompose.renderer.ToRadioButton
+import com.jesusdmedinac.jsontocompose.renderer.ToRichTooltip
 import com.jesusdmedinac.jsontocompose.renderer.ToRow
 import com.jesusdmedinac.jsontocompose.renderer.ToScaffold
 import com.jesusdmedinac.jsontocompose.renderer.ToScrollableTabRow
+import com.jesusdmedinac.jsontocompose.renderer.ToSearchBar
+import com.jesusdmedinac.jsontocompose.renderer.ToSegmentedButton
+import com.jesusdmedinac.jsontocompose.renderer.ToSingleChoiceSegmentedButtonRow
+import com.jesusdmedinac.jsontocompose.renderer.ToSlider
+import com.jesusdmedinac.jsontocompose.renderer.ToSnackbarHost
 import com.jesusdmedinac.jsontocompose.renderer.ToSpacer
+import com.jesusdmedinac.jsontocompose.renderer.ToSuggestionChip
+import com.jesusdmedinac.jsontocompose.renderer.ToSurface
 import com.jesusdmedinac.jsontocompose.renderer.ToSwitch
 import com.jesusdmedinac.jsontocompose.renderer.ToTab
 import com.jesusdmedinac.jsontocompose.renderer.ToTabRow
 import com.jesusdmedinac.jsontocompose.renderer.ToText
 import com.jesusdmedinac.jsontocompose.renderer.ToTextField
+import com.jesusdmedinac.jsontocompose.renderer.ToTimePicker
 import com.jesusdmedinac.jsontocompose.renderer.ToTopAppBar
+import com.jesusdmedinac.jsontocompose.renderer.ToVerticalDivider
+import com.jesusdmedinac.jsontocompose.renderer.ToVerticalPager
 import com.jesusdmedinac.jsontocompose.state.StateHost
 import kotlinx.serialization.json.Json
 import org.jetbrains.compose.resources.DrawableResource
@@ -142,6 +170,38 @@ fun ComposeNode.ToCompose() {
         ComposeType.BottomNavigationItem -> ToBottomNavigationItem()
         ComposeType.Switch -> ToSwitch()
         ComposeType.Checkbox -> ToCheckbox()
+
+        // --- Phase 3: Stub routes ---
+        ComposeType.Slider -> ToSlider()
+        ComposeType.RadioButton -> ToRadioButton()
+        ComposeType.SingleChoiceSegmentedButtonRow -> ToSingleChoiceSegmentedButtonRow()
+        ComposeType.MultiChoiceSegmentedButtonRow -> ToMultiChoiceSegmentedButtonRow()
+        ComposeType.SegmentedButton -> ToSegmentedButton()
+        ComposeType.DatePicker -> ToDatePicker()
+        ComposeType.TimePicker -> ToTimePicker()
+        ComposeType.SearchBar -> ToSearchBar()
+        ComposeType.HorizontalDivider -> ToHorizontalDivider()
+        ComposeType.VerticalDivider -> ToVerticalDivider()
+        ComposeType.FlowRow -> ToFlowRow()
+        ComposeType.FlowColumn -> ToFlowColumn()
+        ComposeType.Surface -> ToSurface()
+        ComposeType.HorizontalPager -> ToHorizontalPager()
+        ComposeType.VerticalPager -> ToVerticalPager()
+        ComposeType.ModalBottomSheet -> ToModalBottomSheet()
+        ComposeType.Badge -> ToBadge()
+        ComposeType.BadgedBox -> ToBadgedBox()
+        ComposeType.AssistChip -> ToAssistChip()
+        ComposeType.FilterChip -> ToFilterChip()
+        ComposeType.InputChip -> ToInputChip()
+        ComposeType.SuggestionChip -> ToSuggestionChip()
+        ComposeType.CircularProgressIndicator -> ToCircularProgressIndicator()
+        ComposeType.LinearProgressIndicator -> ToLinearProgressIndicator()
+        ComposeType.PlainTooltip -> ToPlainTooltip()
+        ComposeType.RichTooltip -> ToRichTooltip()
+        ComposeType.SnackbarHost -> ToSnackbarHost()
+        ComposeType.ListItem -> ToListItem()
+
         ComposeType.Custom -> ToCustom()
     }
 }
+

--- a/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/model/ComposeModifier.kt
+++ b/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/model/ComposeModifier.kt
@@ -185,5 +185,173 @@ data class ComposeModifier(
         ) : Operation(
             modifierOperation = ModifierOperation.Rotate
         )
+
+        // --- Phase 3: Missing Modifiers ---
+
+        /** Makes the component clickable. Event resolved via LocalBehavior. */
+        @Serializable
+        @SerialName("Clickable")
+        data class Clickable(
+            val onClickEventName: String? = null
+        ) : Operation(
+            modifierOperation = ModifierOperation.Clickable
+        )
+
+        /** Assigns a weight within a Row or Column scope. */
+        @Serializable
+        @SerialName("Weight")
+        data class Weight(
+            val weight: Float
+        ) : Operation(
+            modifierOperation = ModifierOperation.Weight
+        )
+
+        /** Enables vertical scrolling on the component. */
+        @Serializable
+        @SerialName("VerticalScroll")
+        data object VerticalScroll : Operation(
+            modifierOperation = ModifierOperation.VerticalScroll
+        )
+
+        /** Enables horizontal scrolling on the component. */
+        @Serializable
+        @SerialName("HorizontalScroll")
+        data object HorizontalScroll : Operation(
+            modifierOperation = ModifierOperation.HorizontalScroll
+        )
+
+        /**
+         * Offsets the component by x and y dp.
+         *
+         * @property x Horizontal offset in dp (positive = right).
+         * @property y Vertical offset in dp (positive = down).
+         */
+        @Serializable
+        @SerialName("Offset")
+        data class Offset(
+            val x: Int = 0,
+            val y: Int = 0
+        ) : Operation(
+            modifierOperation = ModifierOperation.Offset
+        )
+
+        /**
+         * Sets explicit width and height for the component.
+         *
+         * @property width Width in dp.
+         * @property height Height in dp.
+         */
+        @Serializable
+        @SerialName("Size")
+        data class Size(
+            val width: Int,
+            val height: Int
+        ) : Operation(
+            modifierOperation = ModifierOperation.Size
+        )
+
+        /** Wraps the component's width to its content. */
+        @Serializable
+        @SerialName("WrapContentWidth")
+        data object WrapContentWidth : Operation(
+            modifierOperation = ModifierOperation.WrapContentWidth
+        )
+
+        /** Wraps the component's height to its content. */
+        @Serializable
+        @SerialName("WrapContentHeight")
+        data object WrapContentHeight : Operation(
+            modifierOperation = ModifierOperation.WrapContentHeight
+        )
+
+        /**
+         * Constrains the component to a specific aspect ratio.
+         *
+         * @property ratio Width-to-height ratio (e.g., 16f/9f for 16:9).
+         */
+        @Serializable
+        @SerialName("AspectRatio")
+        data class AspectRatio(
+            val ratio: Float
+        ) : Operation(
+            modifierOperation = ModifierOperation.AspectRatio
+        )
+
+        /**
+         * Sets the z-index for overlay ordering.
+         *
+         * @property zIndex Z-index value. Higher values are drawn on top.
+         */
+        @Serializable
+        @SerialName("ZIndex")
+        data class ZIndex(
+            val zIndex: Float
+        ) : Operation(
+            modifierOperation = ModifierOperation.ZIndex
+        )
+
+        /**
+         * Sets a minimum width for the component.
+         *
+         * @property value Minimum width in dp.
+         */
+        @Serializable
+        @SerialName("MinWidth")
+        data class MinWidth(val value: Int) : Operation(
+            modifierOperation = ModifierOperation.MinWidth
+        )
+
+        /**
+         * Sets a minimum height for the component.
+         *
+         * @property value Minimum height in dp.
+         */
+        @Serializable
+        @SerialName("MinHeight")
+        data class MinHeight(val value: Int) : Operation(
+            modifierOperation = ModifierOperation.MinHeight
+        )
+
+        /**
+         * Sets a maximum width for the component.
+         *
+         * @property value Maximum width in dp.
+         */
+        @Serializable
+        @SerialName("MaxWidth")
+        data class MaxWidth(val value: Int) : Operation(
+            modifierOperation = ModifierOperation.MaxWidth
+        )
+
+        /**
+         * Sets a maximum height for the component.
+         *
+         * @property value Maximum height in dp.
+         */
+        @Serializable
+        @SerialName("MaxHeight")
+        data class MaxHeight(val value: Int) : Operation(
+            modifierOperation = ModifierOperation.MaxHeight
+        )
+
+        /** Animates size changes of the component's content. */
+        @Serializable
+        @SerialName("AnimateContentSize")
+        data object AnimateContentSize : Operation(
+            modifierOperation = ModifierOperation.AnimateContentSize
+        )
+
+        /**
+         * Applies a test tag for UI test identification.
+         *
+         * @property tag The tag string used for test identification.
+         */
+        @Serializable
+        @SerialName("TestTag")
+        data class TestTag(
+            val tag: String
+        ) : Operation(
+            modifierOperation = ModifierOperation.TestTag
+        )
     }
 }

--- a/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/model/ComposeType.kt
+++ b/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/model/ComposeType.kt
@@ -83,6 +83,77 @@ enum class ComposeType {
     Switch,
     /** Material checkbox. Uses [NodeProperties.CheckboxProps]. */
     Checkbox,
+
+    // --- Phase 3: Input Components ---
+    /** Material 3 Slider for selecting a value from a range. Uses [NodeProperties.SliderProps]. */
+    Slider,
+    /** Material 3 RadioButton for single selection. Uses [NodeProperties.RadioButtonProps]. */
+    RadioButton,
+    /** Material 3 SingleChoiceSegmentedButtonRow container. Uses [NodeProperties.SegmentedButtonRowProps]. */
+    SingleChoiceSegmentedButtonRow,
+    /** Material 3 MultiChoiceSegmentedButtonRow container. Uses [NodeProperties.SegmentedButtonRowProps]. */
+    MultiChoiceSegmentedButtonRow,
+    /** Material 3 SegmentedButton item. Uses [NodeProperties.SegmentedButtonProps]. */
+    SegmentedButton,
+    /** Material 3 DatePicker. Uses [NodeProperties.DatePickerProps]. */
+    DatePicker,
+    /** Material 3 TimePicker. Uses [NodeProperties.TimePickerProps]. */
+    TimePicker,
+    /** Material 3 SearchBar. Uses [NodeProperties.SearchBarProps]. */
+    SearchBar,
+
+    // --- Phase 3: Layout Components ---
+    /** Material 3 HorizontalDivider. Uses [NodeProperties.DividerProps]. */
+    HorizontalDivider,
+    /** Material 3 VerticalDivider. Uses [NodeProperties.DividerProps]. */
+    VerticalDivider,
+    /** Layout that arranges children horizontally and wraps to the next line. Uses [NodeProperties.FlowRowProps]. */
+    FlowRow,
+    /** Layout that arranges children vertically and wraps to the next column. Uses [NodeProperties.FlowColumnProps]. */
+    FlowColumn,
+    /** Material 3 Surface container. Uses [NodeProperties.SurfaceProps]. */
+    Surface,
+
+    // --- Phase 3: Pager Components ---
+    /** Horizontally scrolling pager. Uses [NodeProperties.PagerProps]. */
+    HorizontalPager,
+    /** Vertically scrolling pager. Uses [NodeProperties.PagerProps]. */
+    VerticalPager,
+
+    // --- Phase 3: ModalBottomSheet ---
+    /** Material 3 ModalBottomSheet. Uses [NodeProperties.ModalBottomSheetProps]. */
+    ModalBottomSheet,
+
+    // --- Phase 3: Display Components ---
+    /** Material 3 Badge. Uses [NodeProperties.BadgeProps]. */
+    Badge,
+    /** Material 3 BadgedBox. Uses [NodeProperties.BadgedBoxProps]. */
+    BadgedBox,
+    /** Material 3 AssistChip. Uses [NodeProperties.ChipProps]. */
+    AssistChip,
+    /** Material 3 FilterChip. Uses [NodeProperties.FilterChipProps]. */
+    FilterChip,
+    /** Material 3 InputChip. Uses [NodeProperties.InputChipProps]. */
+    InputChip,
+    /** Material 3 SuggestionChip. Uses [NodeProperties.ChipProps]. */
+    SuggestionChip,
+    /** Material 3 CircularProgressIndicator. Uses [NodeProperties.ProgressIndicatorProps]. */
+    CircularProgressIndicator,
+    /** Material 3 LinearProgressIndicator. Uses [NodeProperties.ProgressIndicatorProps]. */
+    LinearProgressIndicator,
+    /** Material 3 PlainTooltip. Uses [NodeProperties.PlainTooltipProps]. */
+    PlainTooltip,
+    /** Material 3 RichTooltip. Uses [NodeProperties.RichTooltipProps]. */
+    RichTooltip,
+
+    // --- Phase 3: Snackbar ---
+    /** Material 3 SnackbarHost. Uses [NodeProperties.SnackbarHostProps]. */
+    SnackbarHost,
+
+    // --- Phase 3: ListItem ---
+    /** Material 3 ListItem. Uses [NodeProperties.ListItemProps]. */
+    ListItem,
+
     /** Custom component rendered by a user-provided composable. Uses [NodeProperties.CustomProps]. */
     Custom;
 
@@ -90,7 +161,9 @@ enum class ComposeType {
      * Returns `true` if this type is a layout container (Column, Row, or Box).
      */
     fun isLayout(): Boolean = when (this) {
-        Column, Row, Box, NavigationBar, NavigationRail, TabRow, ScrollableTabRow -> true
+        Column, Row, Box, NavigationBar, NavigationRail, TabRow, ScrollableTabRow,
+        FlowRow, FlowColumn,
+        SingleChoiceSegmentedButtonRow, MultiChoiceSegmentedButtonRow -> true
         else -> false
     }
 
@@ -108,7 +181,10 @@ enum class ComposeType {
         Card,
         ElevatedCard,
         OutlinedCard,
-        ModalNavigationDrawer -> true
+        ModalNavigationDrawer,
+        Surface,
+        ModalBottomSheet,
+        BadgedBox -> true
 
         else -> false
     }

--- a/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/model/NodeProperties.kt
+++ b/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/model/NodeProperties.kt
@@ -623,13 +623,20 @@ sealed interface NodeProperties {
 
     // --- Phase 3: Input Components ---
 
+    /** Range of values for a [ComposeType.Slider] component. */
+    @Serializable
+    data class FloatRange(
+        val start: Float = 0f,
+        val endInclusive: Float = 1f,
+    )
+
     /** Properties for a [ComposeType.Slider] component. */
     @Serializable
     @SerialName("SliderProps")
     data class SliderProps(
         val value: Float? = null,
         val valueStateHostName: String? = null,
-        val valueRange: List<Float>? = null,
+        val valueRange: FloatRange? = null,
         val steps: Int? = null,
         val onValueChangeEventName: String? = null,
         val enabled: Boolean? = null,

--- a/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/model/NodeProperties.kt
+++ b/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/model/NodeProperties.kt
@@ -621,6 +621,263 @@ sealed interface NodeProperties {
         val enabledStateHostName: String? = null,
     ) : NodeProperties
 
+    // --- Phase 3: Input Components ---
+
+    /** Properties for a [ComposeType.Slider] component. */
+    @Serializable
+    @SerialName("SliderProps")
+    data class SliderProps(
+        val value: Float? = null,
+        val valueStateHostName: String? = null,
+        val valueRange: List<Float>? = null,
+        val steps: Int? = null,
+        val onValueChangeEventName: String? = null,
+        val enabled: Boolean? = null,
+        val enabledStateHostName: String? = null,
+    ) : NodeProperties
+
+    /** Properties for a [ComposeType.RadioButton] component. */
+    @Serializable
+    @SerialName("RadioButtonProps")
+    data class RadioButtonProps(
+        val selected: Boolean? = null,
+        val selectedStateHostName: String? = null,
+        val onClickEventName: String? = null,
+        val enabled: Boolean? = null,
+        val enabledStateHostName: String? = null,
+    ) : NodeProperties
+
+    /** Properties for [ComposeType.SingleChoiceSegmentedButtonRow] and [ComposeType.MultiChoiceSegmentedButtonRow]. */
+    @Serializable
+    @SerialName("SegmentedButtonRowProps")
+    data class SegmentedButtonRowProps(
+        val children: List<ComposeNode>? = null,
+    ) : NodeProperties
+
+    /** Properties for a [ComposeType.SegmentedButton] component. */
+    @Serializable
+    @SerialName("SegmentedButtonProps")
+    data class SegmentedButtonProps(
+        val selected: Boolean? = null,
+        val selectedStateHostName: String? = null,
+        val onClickEventName: String? = null,
+        val label: ComposeNode? = null,
+        val icon: ComposeNode? = null,
+        val enabled: Boolean? = null,
+        val enabledStateHostName: String? = null,
+    ) : NodeProperties
+
+    /** Properties for a [ComposeType.DatePicker] component. */
+    @Serializable
+    @SerialName("DatePickerProps")
+    data class DatePickerProps(
+        val selectedDateMillis: Long? = null,
+        val selectedDateMillisStateHostName: String? = null,
+    ) : NodeProperties
+
+    /** Properties for a [ComposeType.TimePicker] component. */
+    @Serializable
+    @SerialName("TimePickerProps")
+    data class TimePickerProps(
+        val hour: Int? = null,
+        val hourStateHostName: String? = null,
+        val minute: Int? = null,
+        val minuteStateHostName: String? = null,
+        val is24Hour: Boolean? = null,
+    ) : NodeProperties
+
+    /** Properties for a [ComposeType.SearchBar] component. */
+    @Serializable
+    @SerialName("SearchBarProps")
+    data class SearchBarProps(
+        val query: String? = null,
+        val queryStateHostName: String? = null,
+        val placeholder: ComposeNode? = null,
+        val leadingIcon: ComposeNode? = null,
+        val trailingIcon: ComposeNode? = null,
+        val active: Boolean? = null,
+        val activeStateHostName: String? = null,
+        val onQueryChangeEventName: String? = null,
+        val children: List<ComposeNode>? = null,
+    ) : NodeProperties
+
+    // --- Phase 3: Layout Components ---
+
+    /** Properties for [ComposeType.HorizontalDivider] and [ComposeType.VerticalDivider]. */
+    @Serializable
+    @SerialName("DividerProps")
+    data class DividerProps(
+        val thickness: Int? = null,
+        val color: String? = null,
+    ) : NodeProperties
+
+    /** Properties for a [ComposeType.FlowRow] component. */
+    @Serializable
+    @SerialName("FlowRowProps")
+    data class FlowRowProps(
+        val children: List<ComposeNode>? = null,
+        val horizontalArrangement: String? = null,
+        val verticalArrangement: String? = null,
+    ) : NodeProperties
+
+    /** Properties for a [ComposeType.FlowColumn] component. */
+    @Serializable
+    @SerialName("FlowColumnProps")
+    data class FlowColumnProps(
+        val children: List<ComposeNode>? = null,
+        val horizontalArrangement: String? = null,
+        val verticalArrangement: String? = null,
+    ) : NodeProperties
+
+    /** Properties for a [ComposeType.Surface] component. */
+    @Serializable
+    @SerialName("SurfaceProps")
+    data class SurfaceProps(
+        val child: ComposeNode? = null,
+        val tonalElevation: Int? = null,
+        val shadowElevation: Int? = null,
+        val color: String? = null,
+        val shape: String? = null,
+    ) : NodeProperties
+
+    // --- Phase 3: Pager Components ---
+
+    /** Properties for [ComposeType.HorizontalPager] and [ComposeType.VerticalPager]. */
+    @Serializable
+    @SerialName("PagerProps")
+    data class PagerProps(
+        val pages: List<ComposeNode>? = null,
+        val currentPage: Int? = null,
+        val currentPageStateHostName: String? = null,
+        val beyondViewportPageCount: Int? = null,
+        val userScrollEnabled: Boolean? = null,
+        val userScrollEnabledStateHostName: String? = null,
+    ) : NodeProperties
+
+    // --- Phase 3: ModalBottomSheet ---
+
+    /** Properties for a [ComposeType.ModalBottomSheet] component. */
+    @Serializable
+    @SerialName("ModalBottomSheetProps")
+    data class ModalBottomSheetProps(
+        val child: ComposeNode? = null,
+        val visible: Boolean? = null,
+        val visibleStateHostName: String? = null,
+        val onDismissRequestEventName: String? = null,
+        val dragHandle: ComposeNode? = null,
+        val shape: String? = null,
+        val scrimColor: String? = null,
+    ) : NodeProperties
+
+    // --- Phase 3: Display Components ---
+
+    /** Properties for a [ComposeType.Badge] component. */
+    @Serializable
+    @SerialName("BadgeProps")
+    data class BadgeProps(
+        val text: String? = null,
+        val textStateHostName: String? = null,
+        val containerColor: String? = null,
+        val contentColor: String? = null,
+    ) : NodeProperties
+
+    /** Properties for a [ComposeType.BadgedBox] component. */
+    @Serializable
+    @SerialName("BadgedBoxProps")
+    data class BadgedBoxProps(
+        val badge: ComposeNode? = null,
+        val child: ComposeNode? = null,
+    ) : NodeProperties
+
+    /** Properties for [ComposeType.AssistChip] and [ComposeType.SuggestionChip]. */
+    @Serializable
+    @SerialName("ChipProps")
+    data class ChipProps(
+        val label: ComposeNode? = null,
+        val leadingIcon: ComposeNode? = null,
+        val onClickEventName: String? = null,
+        val enabled: Boolean? = null,
+        val enabledStateHostName: String? = null,
+    ) : NodeProperties
+
+    /** Properties for a [ComposeType.FilterChip] component. */
+    @Serializable
+    @SerialName("FilterChipProps")
+    data class FilterChipProps(
+        val selected: Boolean? = null,
+        val selectedStateHostName: String? = null,
+        val label: ComposeNode? = null,
+        val leadingIcon: ComposeNode? = null,
+        val onClickEventName: String? = null,
+        val enabled: Boolean? = null,
+        val enabledStateHostName: String? = null,
+    ) : NodeProperties
+
+    /** Properties for a [ComposeType.InputChip] component. */
+    @Serializable
+    @SerialName("InputChipProps")
+    data class InputChipProps(
+        val selected: Boolean? = null,
+        val selectedStateHostName: String? = null,
+        val label: ComposeNode? = null,
+        val leadingIcon: ComposeNode? = null,
+        val trailingIcon: ComposeNode? = null,
+        val onClickEventName: String? = null,
+        val enabled: Boolean? = null,
+        val enabledStateHostName: String? = null,
+    ) : NodeProperties
+
+    /** Properties for [ComposeType.CircularProgressIndicator] and [ComposeType.LinearProgressIndicator]. */
+    @Serializable
+    @SerialName("ProgressIndicatorProps")
+    data class ProgressIndicatorProps(
+        val progress: Float? = null,
+        val progressStateHostName: String? = null,
+        val color: String? = null,
+        val trackColor: String? = null,
+    ) : NodeProperties
+
+    /** Properties for a [ComposeType.PlainTooltip] component. */
+    @Serializable
+    @SerialName("PlainTooltipProps")
+    data class PlainTooltipProps(
+        val text: String? = null,
+        val anchor: ComposeNode? = null,
+    ) : NodeProperties
+
+    /** Properties for a [ComposeType.RichTooltip] component. */
+    @Serializable
+    @SerialName("RichTooltipProps")
+    data class RichTooltipProps(
+        val title: ComposeNode? = null,
+        val text: ComposeNode? = null,
+        val action: ComposeNode? = null,
+        val anchor: ComposeNode? = null,
+    ) : NodeProperties
+
+    // --- Phase 3: Snackbar ---
+
+    /** Properties for a [ComposeType.SnackbarHost] component. */
+    @Serializable
+    @SerialName("SnackbarHostProps")
+    data class SnackbarHostProps(
+        val snackbarHostStateHostName: String? = null,
+    ) : NodeProperties
+
+    // --- Phase 3: ListItem ---
+
+    /** Properties for a [ComposeType.ListItem] component. */
+    @Serializable
+    @SerialName("ListItemProps")
+    data class ListItemProps(
+        val headlineContent: ComposeNode? = null,
+        val supportingContent: ComposeNode? = null,
+        val overlineContent: ComposeNode? = null,
+        val leadingContent: ComposeNode? = null,
+        val trailingContent: ComposeNode? = null,
+        val onClickEventName: String? = null,
+    ) : NodeProperties
+
     /**
      * Properties for a [ComposeType.Custom] component.
      *

--- a/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/modifier/ModifierMapper.kt
+++ b/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/modifier/ModifierMapper.kt
@@ -1,15 +1,29 @@
 package com.jesusdmedinac.jsontocompose.modifier
 
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
@@ -17,7 +31,9 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import com.jesusdmedinac.jsontocompose.model.ComposeModifier
 import com.jesusdmedinac.jsontocompose.model.ComposeShape
 import com.jesusdmedinac.jsontocompose.renderer.toColor
@@ -41,7 +57,25 @@ enum class ModifierOperation {
     Clip,
     Background,
     Alpha,
-    Rotate;
+    Rotate,
+
+    // --- Phase 3: Missing Modifiers ---
+    Clickable,
+    Weight,
+    VerticalScroll,
+    HorizontalScroll,
+    Offset,
+    Size,
+    WrapContentWidth,
+    WrapContentHeight,
+    AspectRatio,
+    ZIndex,
+    MinWidth,
+    MinHeight,
+    MaxWidth,
+    MaxHeight,
+    AnimateContentSize,
+    TestTag;
 }
 
 /**
@@ -52,6 +86,7 @@ enum class ModifierOperation {
  * @param composeModifier The modifier descriptor containing the operations to apply.
  * @return A new [Modifier] with all operations applied.
  */
+@Composable
 infix fun Modifier.from(composeModifier: ComposeModifier): Modifier {
     var result = this
     composeModifier.operations.forEach { operation ->
@@ -83,6 +118,24 @@ infix fun Modifier.from(composeModifier: ComposeModifier): Modifier {
 
             is ComposeModifier.Operation.Alpha -> result.alpha(operation.value)
             is ComposeModifier.Operation.Rotate -> result.rotate(operation.degrees)
+
+            // --- Phase 3: Missing Modifiers (stubs) ---
+            is ComposeModifier.Operation.Clickable -> result.clickable { /* resolved via LocalBehavior at render time */ }
+            is ComposeModifier.Operation.Weight -> result // Weight requires RowScope/ColumnScope — applied contextually by renderers
+            is ComposeModifier.Operation.VerticalScroll -> result.verticalScroll(rememberScrollState())
+            is ComposeModifier.Operation.HorizontalScroll -> result.horizontalScroll(rememberScrollState())
+            is ComposeModifier.Operation.Offset -> result.offset(x = operation.x.dp, y = operation.y.dp)
+            is ComposeModifier.Operation.Size -> result.size(operation.width.dp, operation.height.dp)
+            is ComposeModifier.Operation.WrapContentWidth -> result.wrapContentWidth()
+            is ComposeModifier.Operation.WrapContentHeight -> result.wrapContentHeight()
+            is ComposeModifier.Operation.AspectRatio -> result.aspectRatio(operation.ratio)
+            is ComposeModifier.Operation.ZIndex -> result.zIndex(operation.zIndex)
+            is ComposeModifier.Operation.MinWidth -> result.defaultMinSize(minWidth = operation.value.dp)
+            is ComposeModifier.Operation.MinHeight -> result.defaultMinSize(minHeight = operation.value.dp)
+            is ComposeModifier.Operation.MaxWidth -> result.widthIn(max = operation.value.dp)
+            is ComposeModifier.Operation.MaxHeight -> result.heightIn(max = operation.value.dp)
+            is ComposeModifier.Operation.AnimateContentSize -> result.animateContentSize()
+            is ComposeModifier.Operation.TestTag -> result.testTag(operation.tag)
         }
     }
     return result

--- a/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/modifier/ModifierMapper.kt
+++ b/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/modifier/ModifierMapper.kt
@@ -125,7 +125,7 @@ infix fun Modifier.from(composeModifier: ComposeModifier): Modifier {
             // --- Phase 3: Missing Modifiers ---
             is ComposeModifier.Operation.Clickable -> {
                 val behavior = LocalBehavior.current[operation.onClickEventName]
-                result.clickable { behavior?.onClick() }
+                result.clickable { behavior?.invoke() }
             }
             is ComposeModifier.Operation.Weight -> result // Weight requiere RowScope/ColumnScope — aplicado contextualmente por renderizadores
             is ComposeModifier.Operation.VerticalScroll -> {

--- a/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/modifier/ModifierMapper.kt
+++ b/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/modifier/ModifierMapper.kt
@@ -20,10 +20,12 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
@@ -34,6 +36,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import com.jesusdmedinac.jsontocompose.LocalBehavior
 import com.jesusdmedinac.jsontocompose.model.ComposeModifier
 import com.jesusdmedinac.jsontocompose.model.ComposeShape
 import com.jesusdmedinac.jsontocompose.renderer.toColor
@@ -119,11 +122,24 @@ infix fun Modifier.from(composeModifier: ComposeModifier): Modifier {
             is ComposeModifier.Operation.Alpha -> result.alpha(operation.value)
             is ComposeModifier.Operation.Rotate -> result.rotate(operation.degrees)
 
-            // --- Phase 3: Missing Modifiers (stubs) ---
-            is ComposeModifier.Operation.Clickable -> result.clickable { /* resolved via LocalBehavior at render time */ }
-            is ComposeModifier.Operation.Weight -> result // Weight requires RowScope/ColumnScope — applied contextually by renderers
-            is ComposeModifier.Operation.VerticalScroll -> result.verticalScroll(rememberScrollState())
-            is ComposeModifier.Operation.HorizontalScroll -> result.horizontalScroll(rememberScrollState())
+            // --- Phase 3: Missing Modifiers ---
+            is ComposeModifier.Operation.Clickable -> {
+                val behavior = LocalBehavior.current[operation.onClickEventName]
+                result.clickable { behavior?.onClick() }
+            }
+            is ComposeModifier.Operation.Weight -> result // Weight requiere RowScope/ColumnScope — aplicado contextualmente por renderizadores
+            is ComposeModifier.Operation.VerticalScroll -> {
+                val scrollState = rememberSaveable(operation, saver = ScrollState.Saver) {
+                    ScrollState(0)
+                }
+                result.verticalScroll(scrollState)
+            }
+            is ComposeModifier.Operation.HorizontalScroll -> {
+                val scrollState = rememberSaveable(operation, saver = ScrollState.Saver) {
+                    ScrollState(0)
+                }
+                result.horizontalScroll(scrollState)
+            }
             is ComposeModifier.Operation.Offset -> result.offset(x = operation.x.dp, y = operation.y.dp)
             is ComposeModifier.Operation.Size -> result.size(operation.width.dp, operation.height.dp)
             is ComposeModifier.Operation.WrapContentWidth -> result.wrapContentWidth()

--- a/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/renderer/StubRenderer.kt
+++ b/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/renderer/StubRenderer.kt
@@ -1,0 +1,171 @@
+package com.jesusdmedinac.jsontocompose.renderer
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.jesusdmedinac.jsontocompose.model.ComposeNode
+import com.jesusdmedinac.jsontocompose.modifier.from
+
+/**
+ * Temporary stub renderers for Phase 3 components.
+ *
+ * Each stub renders an empty [Box] with the component's type name as a testTag,
+ * so that the system can route any new component without crashing and the component
+ * is identifiable in tests. These stubs will be replaced with full implementations
+ * scenario by scenario.
+ */
+
+// --- Input Components ---
+
+@Composable
+fun ComposeNode.ToSlider() {
+    Box(modifier = (Modifier from composeModifier).testTag(type.name))
+}
+
+@Composable
+fun ComposeNode.ToRadioButton() {
+    Box(modifier = (Modifier from composeModifier).testTag(type.name))
+}
+
+@Composable
+fun ComposeNode.ToSingleChoiceSegmentedButtonRow() {
+    Box(modifier = (Modifier from composeModifier).testTag(type.name))
+}
+
+@Composable
+fun ComposeNode.ToMultiChoiceSegmentedButtonRow() {
+    Box(modifier = (Modifier from composeModifier).testTag(type.name))
+}
+
+@Composable
+fun ComposeNode.ToSegmentedButton() {
+    Box(modifier = (Modifier from composeModifier).testTag(type.name))
+}
+
+@Composable
+fun ComposeNode.ToDatePicker() {
+    Box(modifier = (Modifier from composeModifier).testTag(type.name))
+}
+
+@Composable
+fun ComposeNode.ToTimePicker() {
+    Box(modifier = (Modifier from composeModifier).testTag(type.name))
+}
+
+@Composable
+fun ComposeNode.ToSearchBar() {
+    Box(modifier = (Modifier from composeModifier).testTag(type.name))
+}
+
+// --- Layout Components ---
+
+@Composable
+fun ComposeNode.ToHorizontalDivider() {
+    Box(modifier = (Modifier from composeModifier).testTag(type.name))
+}
+
+@Composable
+fun ComposeNode.ToVerticalDivider() {
+    Box(modifier = (Modifier from composeModifier).testTag(type.name))
+}
+
+@Composable
+fun ComposeNode.ToFlowRow() {
+    Box(modifier = (Modifier from composeModifier).testTag(type.name))
+}
+
+@Composable
+fun ComposeNode.ToFlowColumn() {
+    Box(modifier = (Modifier from composeModifier).testTag(type.name))
+}
+
+@Composable
+fun ComposeNode.ToSurface() {
+    Box(modifier = (Modifier from composeModifier).testTag(type.name))
+}
+
+// --- Pager Components ---
+
+@Composable
+fun ComposeNode.ToHorizontalPager() {
+    Box(modifier = (Modifier from composeModifier).testTag(type.name))
+}
+
+@Composable
+fun ComposeNode.ToVerticalPager() {
+    Box(modifier = (Modifier from composeModifier).testTag(type.name))
+}
+
+// --- ModalBottomSheet ---
+
+@Composable
+fun ComposeNode.ToModalBottomSheet() {
+    Box(modifier = (Modifier from composeModifier).testTag(type.name))
+}
+
+// --- Display Components ---
+
+@Composable
+fun ComposeNode.ToBadge() {
+    Box(modifier = (Modifier from composeModifier).testTag(type.name))
+}
+
+@Composable
+fun ComposeNode.ToBadgedBox() {
+    Box(modifier = (Modifier from composeModifier).testTag(type.name))
+}
+
+@Composable
+fun ComposeNode.ToAssistChip() {
+    Box(modifier = (Modifier from composeModifier).testTag(type.name))
+}
+
+@Composable
+fun ComposeNode.ToFilterChip() {
+    Box(modifier = (Modifier from composeModifier).testTag(type.name))
+}
+
+@Composable
+fun ComposeNode.ToInputChip() {
+    Box(modifier = (Modifier from composeModifier).testTag(type.name))
+}
+
+@Composable
+fun ComposeNode.ToSuggestionChip() {
+    Box(modifier = (Modifier from composeModifier).testTag(type.name))
+}
+
+@Composable
+fun ComposeNode.ToCircularProgressIndicator() {
+    Box(modifier = (Modifier from composeModifier).testTag(type.name))
+}
+
+@Composable
+fun ComposeNode.ToLinearProgressIndicator() {
+    Box(modifier = (Modifier from composeModifier).testTag(type.name))
+}
+
+@Composable
+fun ComposeNode.ToPlainTooltip() {
+    Box(modifier = (Modifier from composeModifier).testTag(type.name))
+}
+
+@Composable
+fun ComposeNode.ToRichTooltip() {
+    Box(modifier = (Modifier from composeModifier).testTag(type.name))
+}
+
+// --- Snackbar ---
+
+@Composable
+fun ComposeNode.ToSnackbarHost() {
+    Box(modifier = (Modifier from composeModifier).testTag(type.name))
+}
+
+// --- ListItem ---
+
+@Composable
+fun ComposeNode.ToListItem() {
+    Box(modifier = (Modifier from composeModifier).testTag(type.name))
+}


### PR DESCRIPTION
## Summary

Scaffolds all pending Phase 3 component types, modifier operations, and router wiring so that parallel work on individual features can proceed without Git conflicts.

### Changes

**Scenario 1: Scaffold pending Component Types**
- Added 28 new entries to `ComposeType` enum (Input, Layout, Pager, ModalBottomSheet, Display, Snackbar, ListItem)
- Added 23 new `NodeProperties` data classes with serialization annotations and nullable defaults
- Updated `isLayout()` and `hasChild()` in `ComposeType`

**Scenario 2: Scaffold pending Modifier Operations**
- Added 16 new entries to `ModifierOperation` enum
- Added 16 new `ComposeModifier.Operation` sealed class entries
- Implemented stub mappings in `ModifierMapper.kt`
- Made `Modifier.from()` `@Composable` to support `rememberScrollState()`

**Scenario 3: Wire the main Router**
- Created `StubRenderer.kt` with 28 stub renderers (empty Box with testTag)
- Added all 28 new component routes to `ComposeNode.ToCompose()`
- Updated composy `ComposeComponents.kt` (icon mappings) and `EditNodeScreenModel.kt` (modifier defaults)

### Validation
- ✅ `./gradlew :library:desktopTest` — BUILD SUCCESSFUL
- ✅ `./gradlew :composy:compileKotlinDesktop` — BUILD SUCCESSFUL

Closes #66