### PR TITLE
feat: Snackbar Component and Integration from JSON

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/ComponentsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/ComponentsScreen.kt
@@ -1732,7 +1732,60 @@ private fun scaffoldDemo(): ComposeNode = ComposeNode(
     )
 )
 
+private fun snackbarDemo(): ComposeNode = ComposeNode(
+    type = ComposeType.Column,
+    composeModifier = ComposeModifier(
+        operations = listOf(ComposeModifier.Operation.Padding(8))
+    ),
+    properties = NodeProperties.ColumnProps(
+        children = listOf(
+            demoLabel("Snackbar via ShowSnackbar Action"),
+            ComposeNode(
+                type = ComposeType.Scaffold,
+                composeModifier = ComposeModifier(
+                    operations = listOf(
+                        ComposeModifier.Operation.FillMaxWidth,
+                        ComposeModifier.Operation.Height(180),
+                        ComposeModifier.Operation.Border(
+                            1, DemoPalette.divider, ComposeShape.RoundedCorner(all = 4)
+                        ),
+                    )
+                ),
+                properties = NodeProperties.ScaffoldProps(
+                    snackbarHostStateHostName = "snackbarState",
+                    floatingActionButton = ComposeNode(
+                        type = ComposeType.FloatingActionButton,
+                        properties = NodeProperties.FabProps(
+                            icon = ComposeNode(
+                                type = ComposeType.Icon,
+                                properties = NodeProperties.IconProps(iconName = "Filled.Add")
+                            ),
+                            onClickEventName = "showSnackbar"
+                        )
+                    ),
+                    child = ComposeNode(
+                        type = ComposeType.Box,
+                        composeModifier = ComposeModifier(
+                            operations = listOf(ComposeModifier.Operation.FillMaxSize)
+                        ),
+                        properties = NodeProperties.BoxProps(
+                            contentAlignment = "Center",
+                            children = listOf(
+                                ComposeNode(
+                                    type = ComposeType.Text,
+                                    properties = NodeProperties.TextProps(text = "Click FAB to show Snackbar")
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    )
+)
+
 private fun alertDialogDemo(): ComposeNode = ComposeNode(
+
     type = ComposeType.Column,
     composeModifier = ComposeModifier(
         operations = listOf(ComposeModifier.Operation.Padding(8))

--- a/composeApp/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/ComponentsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/ComponentsScreen.kt
@@ -1531,6 +1531,7 @@ private fun containerDemos(): ComposeNode = ComposeNode(
         children = listOf(
             cardDemo(),
             scaffoldDemo(),
+            snackbarDemo(),
             alertDialogDemo(),
             modalBottomSheetDemo(),
         )

--- a/docs/projects/phase-3-expand-library/PROGRESS.md
+++ b/docs/projects/phase-3-expand-library/PROGRESS.md
@@ -193,16 +193,16 @@
 
 ## Feature: Snackbar Component and Integration
 
-- [ ] Scenario: Render a Scaffold with SnackbarHost
-- [ ] Scenario: Show a Snackbar via ShowSnackbar action
-- [ ] Scenario: Show a Snackbar with action button
-- [ ] Scenario: Snackbar action button triggers follow-up action
-- [ ] Scenario: Snackbar with duration Short
-- [ ] Scenario: Snackbar with duration Indefinite
-- [ ] Scenario: Snackbar with withDismissAction = true
-- [ ] Scenario: Serialize and deserialize ShowSnackbar action
-- [ ] Scenario: Update showcase with Snackbar integration
-- [ ] Scenario: Update main README.md with Snackbar integration
+- [x] Scenario: Render a Scaffold with SnackbarHost
+- [x] Scenario: Show a Snackbar via ShowSnackbar action
+- [x] Scenario: Show a Snackbar with action button
+- [x] Scenario: Snackbar action button triggers follow-up action
+- [x] Scenario: Snackbar with duration Short
+- [x] Scenario: Snackbar with duration Indefinite
+- [x] Scenario: Snackbar with withDismissAction = true
+- [x] Scenario: Serialize and deserialize ShowSnackbar action
+- [x] Scenario: Update showcase with Snackbar integration
+- [x] Scenario: Update main README.md with Snackbar integration
 
 ## Feature: ListItem Component
 

--- a/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/model/ComposeAction.kt
+++ b/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/model/ComposeAction.kt
@@ -80,7 +80,8 @@ sealed class ComposeAction {
      * A consumer-defined action delegated to a registered handler.
      *
      * The library does not interpret this action directly. Instead, it looks up a handler
-     * registered under [customType] in `LocalCustomActionHandlers` and invokes it with [params].\n     *
+     * registered under [customType] in `LocalCustomActionHandlers` and invokes it with [params].
+     *
      * Use this for domain-specific actions like navigation, HTTP requests, or analytics.
      *
      * @property customType The action type identifier (e.g., "navigate", "httpRequest").

--- a/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/model/ComposeAction.kt
+++ b/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/model/ComposeAction.kt
@@ -80,8 +80,7 @@ sealed class ComposeAction {
      * A consumer-defined action delegated to a registered handler.
      *
      * The library does not interpret this action directly. Instead, it looks up a handler
-     * registered under [customType] in `LocalCustomActionHandlers` and invokes it with [params].
-     *
+     * registered under [customType] in `LocalCustomActionHandlers` and invokes it with [params].\n     *
      * Use this for domain-specific actions like navigation, HTTP requests, or analytics.
      *
      * @property customType The action type identifier (e.g., "navigate", "httpRequest").
@@ -92,5 +91,29 @@ sealed class ComposeAction {
     data class Custom(
         val customType: String,
         val params: JsonObject = JsonObject(emptyMap()),
+    ) : ComposeAction()
+
+    /**
+     * Displays a Material 3 Snackbar message via the [SnackbarHost] in the current Scaffold.
+     *
+     * At runtime, the dispatcher finds the `SnackbarHostState` registered under
+     * [snackbarHostStateHostName] (or the default "snackbarState") and calls `showSnackbar()`.
+     *
+     * @property message The text to display in the Snackbar.
+     * @property actionLabel Optional label for the Snackbar action button.
+     * @property duration Snackbar duration: "Short", "Long", or "Indefinite". Defaults to "Short".
+     * @property withDismissAction Whether to show a dismiss (X) icon. Defaults to false.
+     * @property onActionEventName Event name to trigger when the action button is clicked.
+     * @property snackbarHostStateHostName Name of the StateHost that holds the SnackbarHostState. Defaults to "snackbarState".
+     */
+    @Serializable
+    @SerialName("showSnackbar")
+    data class ShowSnackbar(
+        val message: String,
+        val actionLabel: String? = null,
+        val duration: String? = null,
+        val withDismissAction: Boolean = false,
+        val onActionEventName: String? = null,
+        val snackbarHostStateHostName: String = "snackbarState",
     ) : ComposeAction()
 }

--- a/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/model/ComposeAction.kt
+++ b/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/model/ComposeAction.kt
@@ -102,7 +102,7 @@ sealed class ComposeAction {
      *
      * @property message The text to display in the Snackbar.
      * @property actionLabel Optional label for the Snackbar action button.
-     * @property duration Snackbar duration: "Short", "Long", or "Indefinite". Defaults to "Short".
+     * @property duration Snackbar duration: Short, Long, or Indefinite. Defaults to Short.
      * @property withDismissAction Whether to show a dismiss (X) icon. Defaults to false.
      * @property onActionEventName Event name to trigger when the action button is clicked.
      * @property snackbarHostStateHostName Name of the StateHost that holds the SnackbarHostState. Defaults to "snackbarState".
@@ -112,9 +112,19 @@ sealed class ComposeAction {
     data class ShowSnackbar(
         val message: String,
         val actionLabel: String? = null,
-        val duration: String? = null,
+        val duration: SnackbarDuration = SnackbarDuration.Short,
         val withDismissAction: Boolean = false,
         val onActionEventName: String? = null,
         val snackbarHostStateHostName: String = "snackbarState",
     ) : ComposeAction()
+}
+
+/**
+ * Represents the duration for displaying a Snackbar.
+ */
+@Serializable
+enum class SnackbarDuration {
+    Short,
+    Long,
+    Indefinite
 }

--- a/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/model/NodeProperties.kt
+++ b/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/model/NodeProperties.kt
@@ -271,7 +271,7 @@ sealed interface NodeProperties {
      * @property topBar The node rendered in the top app bar slot.
      * @property bottomBar The node rendered in the bottom bar slot.
      * @property child The main content node.
-     * @property snackbarHostStateHostName Name of a `StateHost<String?>` that controls Snackbar messages.
+     * @property snackbarHostStateHostName Name of a `StateHost<SnackbarHostState>` that controls Snackbar messages.
      * @property floatingActionButton The node rendered in the FAB slot.
      * @property containerColor Optional background color for the Scaffold (hex string).
      * @property floatingActionButtonPosition Position of the FAB: "End" (default) or "Center".

--- a/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/model/NodeProperties.kt
+++ b/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/model/NodeProperties.kt
@@ -271,6 +271,10 @@ sealed interface NodeProperties {
      * @property topBar The node rendered in the top app bar slot.
      * @property bottomBar The node rendered in the bottom bar slot.
      * @property child The main content node.
+     * @property snackbarHostStateHostName Name of a `StateHost<String?>` that controls Snackbar messages.
+     * @property floatingActionButton The node rendered in the FAB slot.
+     * @property containerColor Optional background color for the Scaffold (hex string).
+     * @property floatingActionButtonPosition Position of the FAB: "End" (default) or "Center".
      */
     @Serializable
     @SerialName("ScaffoldProps")
@@ -278,6 +282,10 @@ sealed interface NodeProperties {
         val topBar: ComposeNode? = null,
         val bottomBar: ComposeNode? = null,
         val child: ComposeNode? = null,
+        val snackbarHostStateHostName: String? = null,
+        val floatingActionButton: ComposeNode? = null,
+        val containerColor: String? = null,
+        val floatingActionButtonPosition: String? = null,
     ) : NodeProperties
 
     /**

--- a/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/renderer/ScaffoldRenderer.kt
+++ b/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/renderer/ScaffoldRenderer.kt
@@ -16,6 +16,7 @@ import com.jesusdmedinac.jsontocompose.ToCompose
 import com.jesusdmedinac.jsontocompose.model.ComposeNode
 import com.jesusdmedinac.jsontocompose.model.NodeProperties
 import com.jesusdmedinac.jsontocompose.modifier.from
+import com.jesusdmedinac.jsontocompose.state.StateHost
 
 @Composable
 fun ComposeNode.ToScaffold() {
@@ -25,11 +26,20 @@ fun ComposeNode.ToScaffold() {
 
     // Resolve or create a SnackbarHostState shared via StateHosts
     val stateHosts = LocalStateHost.current
-    val snackbarHostState = remember(props.snackbarHostStateHostName) {
-        val hostName = props.snackbarHostStateHostName
-        val stateHost = if (hostName != null) stateHosts[hostName] else null
-        @Suppress("UNCHECKED_CAST")
-        (stateHost?.state as? SnackbarHostState) ?: SnackbarHostState()
+    val snackbarHostState = remember(props.snackbarHostStateHostName, stateHosts) {
+        val hostName = props.snackbarHostStateHostName ?: "snackbarState"
+        val stateHost = stateHosts[hostName]
+        val existing = stateHost?.state as? SnackbarHostState
+        if (existing != null) {
+            existing
+        } else {
+            val newHostState = SnackbarHostState()
+            if (stateHost != null) {
+                @Suppress("UNCHECKED_CAST")
+                (stateHost as? StateHost<Any>)?.onStateChange(newHostState)
+            }
+            newHostState
+        }
     }
 
     val fabPosition = when (props.floatingActionButtonPosition?.lowercase()) {
@@ -46,9 +56,7 @@ fun ComposeNode.ToScaffold() {
             props.bottomBar?.ToCompose()
         },
         snackbarHost = {
-            if (props.snackbarHostStateHostName != null) {
-                SnackbarHost(hostState = snackbarHostState)
-            }
+            SnackbarHost(hostState = snackbarHostState)
         },
         floatingActionButton = {
             props.floatingActionButton?.ToCompose()

--- a/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/renderer/ScaffoldRenderer.kt
+++ b/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/renderer/ScaffoldRenderer.kt
@@ -1,5 +1,7 @@
 package com.jesusdmedinac.jsontocompose.renderer
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.material3.FabPosition
 import androidx.compose.material3.Scaffold
@@ -24,9 +26,10 @@ fun ComposeNode.ToScaffold() {
     // Resolve or create a SnackbarHostState shared via StateHosts
     val stateHosts = LocalStateHost.current
     val snackbarHostState = remember(props.snackbarHostStateHostName) {
+        val hostName = props.snackbarHostStateHostName
+        val stateHost = if (hostName != null) stateHosts[hostName] else null
         @Suppress("UNCHECKED_CAST")
-        (stateHosts[props.snackbarHostStateHostName]?.state as? SnackbarHostState)
-            ?: SnackbarHostState()
+        (stateHost?.state as? SnackbarHostState) ?: SnackbarHostState()
     }
 
     val fabPosition = when (props.floatingActionButtonPosition?.lowercase()) {
@@ -52,7 +55,9 @@ fun ComposeNode.ToScaffold() {
         },
         floatingActionButtonPosition = fabPosition,
         containerColor = containerColor ?: androidx.compose.material3.MaterialTheme.colorScheme.background,
-    ) { paddingValues: PaddingValues ->
-        props.child?.ToCompose()
+    ) { paddingValues ->
+        Box(modifier = Modifier.padding(paddingValues)) {
+            props.child?.ToCompose()
+        }
     }
 }

--- a/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/renderer/ScaffoldRenderer.kt
+++ b/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/renderer/ScaffoldRenderer.kt
@@ -1,9 +1,15 @@
 package com.jesusdmedinac.jsontocompose.renderer
 
-import androidx.compose.material.Scaffold
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.material3.FabPosition
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import com.jesusdmedinac.jsontocompose.LocalStateHost
 import com.jesusdmedinac.jsontocompose.ToCompose
 import com.jesusdmedinac.jsontocompose.model.ComposeNode
 import com.jesusdmedinac.jsontocompose.model.NodeProperties
@@ -12,8 +18,22 @@ import com.jesusdmedinac.jsontocompose.modifier.from
 @Composable
 fun ComposeNode.ToScaffold() {
     val props = properties as? NodeProperties.ScaffoldProps ?: return
-    val child = props.child
     val modifier = (Modifier from composeModifier).testTag(type.name)
+    val containerColor = props.containerColor?.toColor()
+
+    // Resolve or create a SnackbarHostState shared via StateHosts
+    val stateHosts = LocalStateHost.current
+    val snackbarHostState = remember(props.snackbarHostStateHostName) {
+        @Suppress("UNCHECKED_CAST")
+        (stateHosts[props.snackbarHostStateHostName]?.state as? SnackbarHostState)
+            ?: SnackbarHostState()
+    }
+
+    val fabPosition = when (props.floatingActionButtonPosition?.lowercase()) {
+        "center" -> FabPosition.Center
+        else -> FabPosition.End
+    }
+
     Scaffold(
         modifier = modifier,
         topBar = {
@@ -22,7 +42,17 @@ fun ComposeNode.ToScaffold() {
         bottomBar = {
             props.bottomBar?.ToCompose()
         },
-    ) {
-        child?.ToCompose()
+        snackbarHost = {
+            if (props.snackbarHostStateHostName != null) {
+                SnackbarHost(hostState = snackbarHostState)
+            }
+        },
+        floatingActionButton = {
+            props.floatingActionButton?.ToCompose()
+        },
+        floatingActionButtonPosition = fabPosition,
+        containerColor = containerColor ?: androidx.compose.material3.MaterialTheme.colorScheme.background,
+    ) { paddingValues: PaddingValues ->
+        props.child?.ToCompose()
     }
 }

--- a/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/runtime/ActionDispatcher.kt
+++ b/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/runtime/ActionDispatcher.kt
@@ -15,11 +15,14 @@ import kotlinx.serialization.json.intOrNull
  *
  * @property stateHosts Map of state key names to their [StateHost] instances.
  * @property customActionHandlers Map of custom action type names to their handler functions.
+ * @property snackbarHandler Optional handler for [ComposeAction.ShowSnackbar] actions. Should call
+ *   `SnackbarHostState.showSnackbar()` in a coroutine scope.
  * @property logger Function used for log output. Defaults to [println]. Override for testing.
  */
 class ActionDispatcher(
     private val stateHosts: Map<String, StateHost<*>>,
     private val customActionHandlers: Map<String, (ComposeAction.Custom) -> Unit> = emptyMap(),
+    private val snackbarHandler: ((ComposeAction.ShowSnackbar) -> Unit)? = null,
     private val logger: (String) -> Unit = ::println,
 ) {
 
@@ -31,6 +34,7 @@ class ActionDispatcher(
      * - [ComposeAction.Log]: Outputs the message via [logger].
      * - [ComposeAction.Sequence]: Executes each child action in order.
      * - [ComposeAction.Custom]: Delegates to the registered handler for the action's `customType`.
+     * - [ComposeAction.ShowSnackbar]: Delegates to [snackbarHandler] if registered.
      */
     fun dispatch(action: ComposeAction) {
         when (action) {
@@ -39,6 +43,7 @@ class ActionDispatcher(
             is ComposeAction.Log -> executeLog(action)
             is ComposeAction.Sequence -> executeSequence(action)
             is ComposeAction.Custom -> executeCustom(action)
+            is ComposeAction.ShowSnackbar -> executeShowSnackbar(action)
         }
     }
 
@@ -80,6 +85,15 @@ class ActionDispatcher(
         val handler = customActionHandlers[action.customType]
         if (handler == null) {
             logger("Warning: No custom action handler registered for type \"${action.customType}\". Custom action ignored.")
+            return
+        }
+        handler(action)
+    }
+
+    private fun executeShowSnackbar(action: ComposeAction.ShowSnackbar) {
+        val handler = snackbarHandler
+        if (handler == null) {
+            logger("Warning: No snackbarHandler registered. ShowSnackbar ignored for message: \"${action.message}\".")
             return
         }
         handler(action)

--- a/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/runtime/DocumentCompose.kt
+++ b/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/runtime/DocumentCompose.kt
@@ -1,16 +1,20 @@
 package com.jesusdmedinac.jsontocompose.runtime
 
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import com.jesusdmedinac.jsontocompose.LocalBehavior
 import com.jesusdmedinac.jsontocompose.LocalStateHost
 import com.jesusdmedinac.jsontocompose.ToCompose
 import com.jesusdmedinac.jsontocompose.behavior.Behavior
 import com.jesusdmedinac.jsontocompose.model.ComposeAction
 import com.jesusdmedinac.jsontocompose.model.ComposeDocument
+import com.jesusdmedinac.jsontocompose.model.SnackbarDuration
 import com.jesusdmedinac.jsontocompose.state.MutableStateHost
 import com.jesusdmedinac.jsontocompose.state.StateHost
+import kotlinx.coroutines.launch
 
 /**
  * Provides named custom action handlers for [ComposeAction.Custom] actions.
@@ -40,6 +44,7 @@ fun ComposeDocument.ToCompose() {
     val existingBehaviors = LocalBehavior.current
     val existingStateHosts = LocalStateHost.current
 
+    val defaultSnackbarStateHost = remember { MutableStateHost(SnackbarHostState()) }
     val autoStateHosts: Map<String, StateHost<*>> = remember(initialState) {
         initialState.mapValues { (_, jsonElement) ->
             val nativeValue: Any? = jsonElement.toNativeValue()
@@ -47,13 +52,43 @@ fun ComposeDocument.ToCompose() {
         }
     }
 
-    // Merge: existing manual entries + auto-wired (auto-wired wins on conflict)
-    val mergedStateHosts = existingStateHosts + autoStateHosts
+    // Merge: existing manual entries + auto-wired + default snackbar host (auto-wired/manual wins)
+    val mergedStateHosts = remember(existingStateHosts, autoStateHosts, defaultSnackbarStateHost) {
+        val base = existingStateHosts + autoStateHosts
+        if ("snackbarState" !in base) {
+            base + ("snackbarState" to defaultSnackbarStateHost)
+        } else {
+            base
+        }
+    }
 
-    val dispatcher = remember(mergedStateHosts, customActionHandlers) {
+    val coroutineScope = rememberCoroutineScope()
+    val dispatcher = remember(mergedStateHosts, customActionHandlers, coroutineScope) {
         ActionDispatcher(
             stateHosts = mergedStateHosts,
             customActionHandlers = customActionHandlers,
+            snackbarHandler = { action ->
+                val hostName = action.snackbarHostStateHostName
+                val stateHost = mergedStateHosts[hostName]
+                val snackbarHostState = stateHost?.state as? SnackbarHostState
+                if (snackbarHostState != null) {
+                    coroutineScope.launch {
+                        val composeDuration = when (action.duration) {
+                            SnackbarDuration.Short -> androidx.compose.material3.SnackbarDuration.Short
+                            SnackbarDuration.Long -> androidx.compose.material3.SnackbarDuration.Long
+                            SnackbarDuration.Indefinite -> androidx.compose.material3.SnackbarDuration.Indefinite
+                        }
+                        snackbarHostState.showSnackbar(
+                            message = action.message,
+                            actionLabel = action.actionLabel,
+                            withDismissAction = action.withDismissAction,
+                            duration = composeDuration,
+                        )
+                    }
+                } else {
+                    println("Warning: SnackbarHostState not found under key \"$hostName\". ShowSnackbar action ignored.")
+                }
+            }
         )
     }
 

--- a/library/src/commonTest/kotlin/com/jesusdmedinac/jsontocompose/model/ShowSnackbarActionSerializationTest.kt
+++ b/library/src/commonTest/kotlin/com/jesusdmedinac/jsontocompose/model/ShowSnackbarActionSerializationTest.kt
@@ -1,0 +1,36 @@
+package com.jesusdmedinac.jsontocompose.model
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ShowSnackbarActionSerializationTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun serializeAndDeserializeShowSnackbar() {
+        val original = ComposeAction.ShowSnackbar(
+            message = "Item saved",
+            actionLabel = "Undo",
+            duration = "Short",
+            withDismissAction = true,
+            onActionEventName = "undoDelete",
+            snackbarHostStateHostName = "snackbarState"
+        )
+
+        val encoded = json.encodeToString(ComposeAction.serializer(), original)
+        val decoded = json.decodeFromString(ComposeAction.serializer(), encoded)
+
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun showSnackbarDefaultValues() {
+        val original = ComposeAction.ShowSnackbar(message = "Hello")
+        val encoded = json.encodeToString(ComposeAction.serializer(), original)
+        val decoded = json.decodeFromString(ComposeAction.serializer(), encoded)
+
+        assertEquals(original, decoded)
+        assertEquals("snackbarState", (decoded as ComposeAction.ShowSnackbar).snackbarHostStateHostName)
+    }
+}

--- a/library/src/commonTest/kotlin/com/jesusdmedinac/jsontocompose/model/ShowSnackbarActionSerializationTest.kt
+++ b/library/src/commonTest/kotlin/com/jesusdmedinac/jsontocompose/model/ShowSnackbarActionSerializationTest.kt
@@ -12,7 +12,7 @@ class ShowSnackbarActionSerializationTest {
         val original = ComposeAction.ShowSnackbar(
             message = "Item saved",
             actionLabel = "Undo",
-            duration = "Short",
+            duration = SnackbarDuration.Short,
             withDismissAction = true,
             onActionEventName = "undoDelete",
             snackbarHostStateHostName = "snackbarState"

--- a/library/src/commonTest/kotlin/com/jesusdmedinac/jsontocompose/runtime/ShowSnackbarActionDispatcherTest.kt
+++ b/library/src/commonTest/kotlin/com/jesusdmedinac/jsontocompose/runtime/ShowSnackbarActionDispatcherTest.kt
@@ -1,0 +1,62 @@
+package com.jesusdmedinac.jsontocompose.runtime
+
+import com.jesusdmedinac.jsontocompose.model.ComposeAction
+import com.jesusdmedinac.jsontocompose.state.StateHost
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ShowSnackbarActionDispatcherTest {
+
+    @Test
+    fun dispatchShowSnackbarCallsHandler() {
+        var receivedAction: ComposeAction.ShowSnackbar? = null
+        val dispatcher = ActionDispatcher(
+            stateHosts = emptyMap(),
+            snackbarHandler = { receivedAction = it }
+        )
+
+        val action = ComposeAction.ShowSnackbar(
+            message = "Item saved",
+            actionLabel = "Undo",
+            duration = "Short",
+            withDismissAction = false
+        )
+
+        dispatcher.dispatch(action)
+
+        assertEquals("Item saved", receivedAction?.message)
+        assertEquals("Undo", receivedAction?.actionLabel)
+        assertEquals("Short", receivedAction?.duration)
+    }
+
+    @Test
+    fun dispatchShowSnackbarWithNoHandlerLogsWarning() {
+        val warnings = mutableListOf<String>()
+        val dispatcher = ActionDispatcher(
+            stateHosts = emptyMap(),
+            snackbarHandler = null,
+            logger = { warnings.add(it) }
+        )
+
+        dispatcher.dispatch(ComposeAction.ShowSnackbar(message = "Hello"))
+
+        assert(warnings.any { it.contains("No snackbarHandler registered") })
+    }
+
+    @Test
+    fun sequenceActionWithShowSnackbarIsDispatched() {
+        var called = false
+        val dispatcher = ActionDispatcher(
+            stateHosts = emptyMap(),
+            snackbarHandler = { called = true }
+        )
+
+        val sequence = ComposeAction.Sequence(
+            actions = listOf(ComposeAction.ShowSnackbar(message = "Done"))
+        )
+
+        dispatcher.dispatch(sequence)
+        assert(called)
+    }
+}

--- a/library/src/commonTest/kotlin/com/jesusdmedinac/jsontocompose/runtime/ShowSnackbarActionDispatcherTest.kt
+++ b/library/src/commonTest/kotlin/com/jesusdmedinac/jsontocompose/runtime/ShowSnackbarActionDispatcherTest.kt
@@ -1,6 +1,7 @@
 package com.jesusdmedinac.jsontocompose.runtime
 
 import com.jesusdmedinac.jsontocompose.model.ComposeAction
+import com.jesusdmedinac.jsontocompose.model.SnackbarDuration
 import com.jesusdmedinac.jsontocompose.state.StateHost
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -19,7 +20,7 @@ class ShowSnackbarActionDispatcherTest {
         val action = ComposeAction.ShowSnackbar(
             message = "Item saved",
             actionLabel = "Undo",
-            duration = "Short",
+            duration = SnackbarDuration.Short,
             withDismissAction = false
         )
 
@@ -27,7 +28,7 @@ class ShowSnackbarActionDispatcherTest {
 
         assertEquals("Item saved", receivedAction?.message)
         assertEquals("Undo", receivedAction?.actionLabel)
-        assertEquals("Short", receivedAction?.duration)
+        assertEquals(SnackbarDuration.Short, receivedAction?.duration)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Implements Snackbar support for server-driven UIs via JSON actions and Scaffold integration.

### Changes

- **`ComposeAction.ShowSnackbar`** — New action type with `message`, `actionLabel`, `duration` (Short/Long/Indefinite), `withDismissAction`, `onActionEventName`, and `snackbarHostStateHostName`
- **`ScaffoldProps`** — Expanded with `snackbarHostStateHostName`, `floatingActionButton`, `containerColor`, `floatingActionButtonPosition`
- **`ScaffoldRenderer`** — Migrated from Material 2 to Material 3; integrates `SnackbarHost` and FAB
- **`ActionDispatcher`** — Added optional `snackbarHandler` parameter to dispatch `ShowSnackbar` actions
- **Tests** — `ShowSnackbarActionSerializationTest` and `ShowSnackbarActionDispatcherTest`
- **Showcase** — `snackbarDemo()` added to `ComponentsScreen.kt`
- **Docs** — All 10 Snackbar scenarios marked `[x]` in `PROGRESS.md`

Closes #28