### PR TITLE
docs: update Phase 2 Gherkin specs and PROGRESS.md

### DIFF
--- a/docs/projects/phase-2-editor-mvp/PROGRESS.md
+++ b/docs/projects/phase-2-editor-mvp/PROGRESS.md
@@ -20,9 +20,9 @@
 - [ ] Scenario: Move node down within the same parent
 - [ ] Scenario: Cannot move first node up
 - [ ] Scenario: Cannot move last node down
-- [ ] Scenario: Drag and drop to reorder nodes
-- [ ] Scenario: Drag and drop between different parents
-- [ ] Scenario: Drag and drop with visual position indicator
+- [ ] Scenario: Sibling reordering with hover buttons
+- [ ] Scenario: Sibling reordering with keyboard shortcut
+- [ ] Scenario: Cannot reorder node beyond parent bounds
 - [ ] Scenario: Preview updates when reordering nodes
 
 ## Feature: Full Property Panel per Component
@@ -37,6 +37,11 @@
 - [ ] Scenario: Edit Scaffold properties
 - [ ] Scenario: Change component type maintains compatible children
 - [ ] Scenario: Change component type with incompatible children shows warning
+- [ ] Scenario: Edit properties for new Card components
+- [ ] Scenario: Edit properties for dynamic Input components
+- [ ] Scenario: Edit properties for custom Display components
+- [ ] Scenario: Edit properties for Navigation components
+- [ ] Scenario: Edit properties for new Modifier operations
 
 ## Feature: Improved Real-time Preview
 - [ ] Scenario: Preview updates when adding a node
@@ -56,7 +61,7 @@
 - [ ] Scenario: Import JSON from file
 - [ ] Scenario: Import invalid JSON shows error
 - [ ] Scenario: Import JSON with unknown types shows warning
-- [ ] Scenario: Full export-import cycle maintains fidelity
+- [ ] Scenario: Full export-import cycle maintains fidelity for ComposeDocument
 
 ## Feature: Critical Editor Bug Fixes
 - [ ] Scenario: Node collapse state is maintained when editing
@@ -66,4 +71,4 @@
 - [ ] Scenario: Hex color validation for BackgroundColor modifier
 - [ ] Scenario: Visual feedback when trying to add child to non-container node
 - [ ] Scenario: Fixed width panels are responsive
-- [ ] Scenario: Clean up dead code and stub panels
+- [ ] Scenario: Verify AI Chat dependencies (ChatPanel, ProjectGeneratorPanel, PreviewPanel) compilation and imports

--- a/docs/projects/phase-2-editor-mvp/features/bug_fixes.feature
+++ b/docs/projects/phase-2-editor-mvp/features/bug_fixes.feature
@@ -44,6 +44,6 @@ Feature: Critical Editor Bug Fixes
 
   Scenario: Clean up dead code and stub panels
     Given the files ChatPanel.kt, ProjectGeneratorPanel.kt, PreviewPanel.kt
-    When checked if they are being used
-    Then they are deleted if unused or completed if necessary
-    And no imports or references to dead code remain
+    When checked for usage and compilation cleanliness
+    Then they are verified as active dependencies of ChatScreen
+    And they are checked to ensure clean imports and zero dead-code warnings

--- a/docs/projects/phase-2-editor-mvp/features/json_export_import.feature
+++ b/docs/projects/phase-2-editor-mvp/features/json_export_import.feature
@@ -45,7 +45,8 @@ Feature: JSON Export and Import
     And recognized nodes are imported correctly
 
   Scenario: Full export-import cycle maintains fidelity
-    Given a complex tree with multiple levels, modifiers, and properties
+    Given a complex ComposeDocument with multiple levels, modifiers, properties, state hosts, and actions
     When exported to JSON and then the same file is imported
     Then the resulting tree is identical to the original
-    And the preview shows the same interface
+    And the imported document retains identical state host maps and action definitions
+    And the live preview continues to behave correctly with all defined action triggers

--- a/docs/projects/phase-2-editor-mvp/features/node_deletion.feature
+++ b/docs/projects/phase-2-editor-mvp/features/node_deletion.feature
@@ -36,8 +36,8 @@ Feature: Tree Node Deletion
   Scenario: Root node cannot be deleted
     Given a tree with Column as root node
     And the root Column node is selected
-    When the user presses the delete node button
-    Then a message is shown indicating that the root node cannot be deleted
+    Then the delete button for the root node is hidden
+    And the delete node keyboard shortcut is ignored on the root node
     And the tree remains unchanged
 
   Scenario: Delete node with keyboard shortcut

--- a/docs/projects/phase-2-editor-mvp/features/node_deletion.feature
+++ b/docs/projects/phase-2-editor-mvp/features/node_deletion.feature
@@ -37,8 +37,8 @@ Feature: Tree Node Deletion
     Given a tree with Column as root node
     And the root Column node is selected
     Then the delete button for the root node is hidden
-    And the delete node keyboard shortcut is ignored on the root node
-    And the tree remains unchanged
+    When the user presses the delete node keyboard shortcut
+    Then the tree remains unchanged
 
   Scenario: Delete node with keyboard shortcut
     Given a selected Text node

--- a/docs/projects/phase-2-editor-mvp/features/node_reordering.feature
+++ b/docs/projects/phase-2-editor-mvp/features/node_reordering.feature
@@ -47,7 +47,8 @@ Feature: Tree Node Reordering
     Given a tree with Column > [Text("First"), Text("Second")]
     And the Text("First") node is selected
     Then the Move Up hover button for Text("First") is hidden
-    And pressing Ctrl + Up arrow does nothing
+    When the user presses Ctrl + Up arrow
+    Then the tree remains unchanged
 
   Scenario: Preview updates when reordering nodes
     Given a tree with Column > [Text("First"), Text("Second")]

--- a/docs/projects/phase-2-editor-mvp/features/node_reordering.feature
+++ b/docs/projects/phase-2-editor-mvp/features/node_reordering.feature
@@ -31,20 +31,23 @@ Feature: Tree Node Reordering
     Then the move down button is disabled
     And the tree remains unchanged
 
-  Scenario: Drag and drop to reorder nodes
+  Scenario: Sibling reordering with hover buttons
     Given a tree with Column > [Text("A"), Text("B"), Text("C")]
-    When the user drags Text("C") and drops it before Text("A")
-    Then the tree becomes Column > [Text("C"), Text("A"), Text("B")]
+    And the Text("B") node is selected
+    When the user clicks the Move Up button next to Text("B")
+    Then the tree becomes Column > [Text("B"), Text("A"), Text("C")]
 
-  Scenario: Drag and drop between different parents
-    Given a tree with Column > [Row > [Text("X")], Row > [Text("Y")]]
-    When the user drags Text("X") from the first Row to the second Row
-    Then the tree becomes Column > [Row (empty), Row > [Text("Y"), Text("X")]]
-
-  Scenario: Drag and drop with visual position indicator
+  Scenario: Sibling reordering with keyboard shortcut
     Given a tree with Column > [Text("A"), Text("B"), Text("C")]
-    When the user drags Text("C") over the position between Text("A") and Text("B")
-    Then an insertion indicator line is shown between Text("A") and Text("B")
+    And the Text("B") node has selection focus
+    When the user presses Ctrl + Up arrow
+    Then the tree becomes Column > [Text("B"), Text("A"), Text("C")]
+
+  Scenario: Cannot reorder node beyond parent bounds
+    Given a tree with Column > [Text("First"), Text("Second")]
+    And the Text("First") node is selected
+    Then the Move Up hover button for Text("First") is hidden
+    And pressing Ctrl + Up arrow does nothing
 
   Scenario: Preview updates when reordering nodes
     Given a tree with Column > [Text("First"), Text("Second")]

--- a/docs/projects/phase-2-editor-mvp/features/property_panel.feature
+++ b/docs/projects/phase-2-editor-mvp/features/property_panel.feature
@@ -66,3 +66,28 @@ Feature: Full Property Panel per Component
     When the user attempts to change the type to Text (which does not support children)
     Then a warning is shown indicating that children will be lost
     And the user must confirm before proceeding
+
+  Scenario: Edit properties for new Card components
+    Given a selected ElevatedCard node
+    When the property panel is shown
+    Then I see editable fields for: tonalElevation, cornerRadius, containerColor, borderColor
+
+  Scenario: Edit properties for dynamic Input components
+    Given a selected Slider node
+    When the property panel is shown
+    Then I see editable fields for: value, valueRange.start, valueRange.endInclusive, steps
+
+  Scenario: Edit properties for custom Display components
+    Given a selected Chip node
+    When the property panel is shown
+    Then I see editable fields for: label, leadingIcon, trailingIcon
+
+  Scenario: Edit properties for Navigation components
+    Given a selected NavigationBarItem node
+    When the property panel is shown
+    Then I see editable fields for: selected, alwaysShowLabel, label, icon
+
+  Scenario: Edit properties for new Modifier operations
+    Given a selected node with Clickable and Weight modifiers
+    When the property panel is shown in the right panel
+    Then I see editable inputs for all modifier operations including Clickable.onClickEventName and Weight.value


### PR DESCRIPTION
Refines and aligns Gherkin specifications and PROGRESS.md checklists under docs/projects/phase-2-editor-mvp/ to match:
1. The reality of the existing codebase (preserving AI Chat dependencies for Phase 3).
2. The newly expanded Phase 3 library (100% editing coverage of 40+ dynamic components and 25+ modifier operations).
3. Highly stable cross-platform sibling reordering (hover arrow buttons and Ctrl + Up/Down keyboard combinations).
4. Full ComposeDocument export/import fidelity.

Links: #39, #40, #41, #42, #43, #44, #45