### PR TITLE
feat: Editor Node and Modifier Deletion

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -14,13 +14,13 @@
 | 2   | [phase-actions-system](#2-phase-actions-system)                   | `library/`    | 37        | 37        | **100%** |
 | 3   | [phase-demo-showcase](#3-phase-demo-showcase)                     | `composeApp/` | 36        | 36        | **100%** |
 | 4   | [phase-3-expand-library](#4-phase-3-expand-library)               | `library/`    | 239       | 239       | **100%** |
-| 5   | [phase-2-editor-mvp](#5-phase-2-editor-mvp)                       | `composy/`    | 58        | 8         | **13%**  |
-| 6   | [phase-4-semantics-testability](#6-phase-4-semantics-testability) | `library/`    | 26        | 0         | **0%**   |
+| 5   | [phase-2-editor-mvp](#5-phase-2-editor-mvp)                       | `composy/`    | 58        | 19        | **32%**  |
+| 6   | [phase-4-semantics-testability](#6-phase-4-semantics-testability) | `library/`    | 30        | 0         | **0%**   |
 | 7   | [phase-3-differentiators](#7-phase-3-differentiators)             | Multi-module  | 37        | 0         | **0%**   |
-|     | **TOTAL**                                                         |               | **620**   | **507**   | **81%**  |
+|     | **TOTAL**                                                         |               | **620**   | **518**   | **83%**  |
 
 ```
-Progress: [████████████████████████████████░░░░░░░] 81%
+Progress: [█████████████████████████████████░░░░░░] 83%
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            phase-1 ✅  actions ✅  demo ✅  expand ✅  editor  sem  diff
 ```
@@ -79,7 +79,7 @@ Progress: [███████████████████████
 
 ### 2. phase-2-editor-mvp
 
-**Status:** 🏗️ In Progress (8/58 — 13%)
+**Status:** 🏗️ In Progress (19/58 — 32%)
 **Module:** `composy/`
 **Depends on:** Benefits from phase-3-expand-library.
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -14,12 +14,12 @@
 | 2   | [phase-actions-system](#2-phase-actions-system)                   | `library/`    | 37        | 37        | **100%** |
 | 3   | [phase-demo-showcase](#3-phase-demo-showcase)                     | `composeApp/` | 36        | 36        | **100%** |
 | 4   | [phase-3-expand-library](#4-phase-3-expand-library)               | `library/`    | 239       | 239       | **100%** |
-| 5   | [phase-2-editor-mvp](#5-phase-2-editor-mvp)                       | `composy/`    | 58        | 19        | **32%**  |
-| 6   | [phase-4-semantics-testability](#6-phase-4-semantics-testability) | `library/`    | 30        | 0         | **0%**   |
-| 7   | [phase-3-differentiators](#7-phase-3-differentiators)             | Multi-module  | 37        | 0         | **0%**   |
+| 5   | [phase-2-editor-mvp](#2-phase-2-editor-mvp)                       | `composy/`    | 58        | 19        | **32%**  |
+| 6   | [phase-4-semantics-testability](#3-phase-4-semantics-testability) | `library/`    | 30        | 0         | **0%**   |
+| 7   | [phase-3-differentiators](#4-phase-3-differentiators)             | Multi-module  | 37        | 0         | **0%**   |
 |     | **TOTAL**                                                         |               | **620**   | **518**   | **83%**  |
 
-```
+```text
 Progress: [█████████████████████████████████░░░░░░] 83%
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            phase-1 ✅  actions ✅  demo ✅  expand ✅  editor  sem  diff

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/ComposeTreeScreenModel.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/ComposeTreeScreenModel.kt
@@ -10,7 +10,17 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 
 class ComposeTreeScreenModel : ScreenModel, ComposeTreeBehavior {
-    private val _state = MutableStateFlow(ComposeTreeState())
+    private val composeNodeRoot = ComposeNode(
+        type = ComposeType.Box,
+        properties = ComposeType.Box.createDefaultProperties()
+    )
+    private val _state = MutableStateFlow(
+        ComposeTreeState(
+            composeNodeRoot = composeNodeRoot,
+            selectedComposeNode = null,
+            collapsedNodes = emptyList()
+        )
+    )
     val state: StateFlow<ComposeTreeState> = _state.asStateFlow()
 
     override fun onAddNewNodeToChildren(composeNode: ComposeNode) {
@@ -138,12 +148,9 @@ class ComposeTreeScreenModel : ScreenModel, ComposeTreeBehavior {
 }
 
 data class ComposeTreeState(
-    val composeNodeRoot: ComposeNode = ComposeNode(
-        type = ComposeType.Box,
-        properties = ComposeType.Box.createDefaultProperties()
-    ),
-    val selectedComposeNode: ComposeNode? = null,
-    val collapsedNodes: List<ComposeNode> = emptyList(),
+    val composeNodeRoot: ComposeNode,
+    val selectedComposeNode: ComposeNode?,
+    val collapsedNodes: List<ComposeNode>,
 ) {
     fun isSelected(composeNode: ComposeNode): Boolean {
         return selectedComposeNode?.id == composeNode.id

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/ComposeTreeScreenModel.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/ComposeTreeScreenModel.kt
@@ -40,6 +40,20 @@ class ComposeTreeScreenModel : ScreenModel, ComposeTreeBehavior {
         }
     }
 
+    override fun deleteNode(composeNode: ComposeNode) {
+        _state.update { state ->
+            if (state.composeNodeRoot.id == composeNode.id) return@update state
+            
+            val nextSelection = findNextSelection(composeNode)
+            val updatedRoot = deleteNodeRecursive(state.composeNodeRoot, composeNode.id)
+            
+            state.copy(
+                composeNodeRoot = updatedRoot ?: state.composeNodeRoot,
+                selectedComposeNode = nextSelection
+            )
+        }
+    }
+
     override fun onNodeExpanded(composeNode: ComposeNode) {
         _state.update { state ->
             val updatedCollapsedNodes = if (state.collapsedNodes.contains(composeNode)) {
@@ -74,6 +88,57 @@ class ComposeTreeScreenModel : ScreenModel, ComposeTreeBehavior {
         
         return currentNode.copy(properties = updatedProps)
     }
+
+    private fun deleteNodeRecursive(
+        currentNode: ComposeNode,
+        targetId: String
+    ): ComposeNode? {
+        if (currentNode.id == targetId) {
+            return null
+        }
+        val updatedProps = when (val props = currentNode.properties) {
+            is NodeProperties.ColumnProps -> {
+                val updatedChildren = props.children?.mapNotNull { child ->
+                    deleteNodeRecursive(child, targetId)
+                } ?: emptyList()
+                props.copy(children = updatedChildren)
+            }
+            is NodeProperties.RowProps -> {
+                val updatedChildren = props.children?.mapNotNull { child ->
+                    deleteNodeRecursive(child, targetId)
+                } ?: emptyList()
+                props.copy(children = updatedChildren)
+            }
+            is NodeProperties.BoxProps -> {
+                val updatedChildren = props.children?.mapNotNull { child ->
+                    deleteNodeRecursive(child, targetId)
+                } ?: emptyList()
+                props.copy(children = updatedChildren)
+            }
+            else -> return currentNode
+        }
+        return currentNode.copy(properties = updatedProps)
+    }
+
+    private fun findNextSelection(targetNode: ComposeNode): ComposeNode? {
+        val parent = targetNode.parent ?: return null
+        
+        val siblings = when (val props = parent.properties) {
+            is NodeProperties.ColumnProps -> props.children ?: emptyList()
+            is NodeProperties.RowProps -> props.children ?: emptyList()
+            is NodeProperties.BoxProps -> props.children ?: emptyList()
+            else -> emptyList()
+        }
+        
+        val targetIndex = siblings.indexOfFirst { it.id == targetNode.id }
+        
+        return when {
+            targetIndex < 0 -> parent
+            targetIndex + 1 < siblings.size -> siblings[targetIndex + 1]
+            targetIndex - 1 >= 0 -> siblings[targetIndex - 1]
+            else -> parent
+        }
+    }
 }
 
 data class ComposeTreeState(
@@ -97,6 +162,7 @@ interface ComposeTreeBehavior {
     fun onAddNewNodeToChildren(composeNode: ComposeNode)
     fun onComposeNodeSelected(composeNode: ComposeNode?)
     fun saveNode(composeNode: ComposeNode)
+    fun deleteNode(composeNode: ComposeNode)
     fun onNodeExpanded(composeNode: ComposeNode)
 
     companion object {
@@ -111,6 +177,10 @@ interface ComposeTreeBehavior {
 
             override fun saveNode(composeNode: ComposeNode) {
                 TODO("saveNode is not yet implemented")
+            }
+
+            override fun deleteNode(composeNode: ComposeNode) {
+                TODO("deleteNode is not yet implemented")
             }
 
             override fun onNodeExpanded(composeNode: ComposeNode) {

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/ComposeTreeScreenModel.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/ComposeTreeScreenModel.kt
@@ -54,6 +54,26 @@ class ComposeTreeScreenModel : ScreenModel, ComposeTreeBehavior {
         }
     }
 
+    override fun deleteModifier(composeNode: ComposeNode, modifierOperationIndex: Int) {
+        _state.update { state ->
+            val oldOperations = composeNode.composeModifier.operations
+            if (modifierOperationIndex !in oldOperations.indices) return@update state
+
+            val newOperations = oldOperations.toMutableList().apply {
+                removeAt(modifierOperationIndex)
+            }
+            val updatedNode = composeNode.copy(
+                composeModifier = composeNode.composeModifier.copy(operations = newOperations)
+            )
+            val updatedRoot = updateNodeRecursive(state.composeNodeRoot, updatedNode)
+
+            state.copy(
+                composeNodeRoot = updatedRoot,
+                selectedComposeNode = if (state.selectedComposeNode?.id == composeNode.id) updatedNode else state.selectedComposeNode
+            )
+        }
+    }
+
     override fun onNodeExpanded(composeNode: ComposeNode) {
         _state.update { state ->
             val updatedCollapsedNodes = if (state.collapsedNodes.contains(composeNode)) {
@@ -96,47 +116,23 @@ class ComposeTreeScreenModel : ScreenModel, ComposeTreeBehavior {
         if (currentNode.id == targetId) {
             return null
         }
-        val updatedProps = when (val props = currentNode.properties) {
-            is NodeProperties.ColumnProps -> {
-                val updatedChildren = props.children?.mapNotNull { child ->
-                    deleteNodeRecursive(child, targetId)
-                } ?: emptyList()
-                props.copy(children = updatedChildren)
-            }
-            is NodeProperties.RowProps -> {
-                val updatedChildren = props.children?.mapNotNull { child ->
-                    deleteNodeRecursive(child, targetId)
-                } ?: emptyList()
-                props.copy(children = updatedChildren)
-            }
-            is NodeProperties.BoxProps -> {
-                val updatedChildren = props.children?.mapNotNull { child ->
-                    deleteNodeRecursive(child, targetId)
-                } ?: emptyList()
-                props.copy(children = updatedChildren)
-            }
-            else -> return currentNode
-        }
+        val visitor = DeleteChildVisitor(targetId, ::deleteNodeRecursive)
+        val updatedProps = currentNode.properties.accept(visitor)
         return currentNode.copy(properties = updatedProps)
     }
 
     private fun findNextSelection(targetNode: ComposeNode): ComposeNode? {
         val parent = targetNode.parent ?: return null
         
-        val siblings = when (val props = parent.properties) {
-            is NodeProperties.ColumnProps -> props.children ?: emptyList()
-            is NodeProperties.RowProps -> props.children ?: emptyList()
-            is NodeProperties.BoxProps -> props.children ?: emptyList()
-            else -> emptyList()
-        }
-        
+        val siblings = parent.children()
         val targetIndex = siblings.indexOfFirst { it.id == targetNode.id }
         
-        return when {
-            targetIndex < 0 -> parent
-            targetIndex + 1 < siblings.size -> siblings[targetIndex + 1]
-            targetIndex - 1 >= 0 -> siblings[targetIndex - 1]
-            else -> parent
+        return if (targetIndex > 0) {
+            siblings[targetIndex - 1]
+        } else if (siblings.size > 1) {
+            siblings[targetIndex + 1]
+        } else {
+            parent
         }
     }
 }
@@ -163,6 +159,7 @@ interface ComposeTreeBehavior {
     fun onComposeNodeSelected(composeNode: ComposeNode?)
     fun saveNode(composeNode: ComposeNode)
     fun deleteNode(composeNode: ComposeNode)
+    fun deleteModifier(composeNode: ComposeNode, modifierOperationIndex: Int)
     fun onNodeExpanded(composeNode: ComposeNode)
 
     companion object {
@@ -181,6 +178,10 @@ interface ComposeTreeBehavior {
 
             override fun deleteNode(composeNode: ComposeNode) {
                 TODO("deleteNode is not yet implemented")
+            }
+
+            override fun deleteModifier(composeNode: ComposeNode, modifierOperationIndex: Int) {
+                TODO("deleteModifier is not yet implemented")
             }
 
             override fun onNodeExpanded(composeNode: ComposeNode) {

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/ComposeTreeScreenModel.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/ComposeTreeScreenModel.kt
@@ -53,13 +53,16 @@ class ComposeTreeScreenModel : ScreenModel, ComposeTreeBehavior {
     override fun deleteNode(composeNode: ComposeNode) {
         _state.update { state ->
             if (state.composeNodeRoot.id == composeNode.id) return@update state
-            
-            val nextSelection = findNextSelection(composeNode)
+
             val updatedRoot = deleteNodeRecursive(state.composeNodeRoot, composeNode.id)
-            
+            val nextSelectionId = findNextSelection(state.composeNodeRoot, composeNode)?.id
+            val resolvedNextSelection = nextSelectionId?.let { id ->
+                updatedRoot?.let { findNodeById(it, id) }
+            }
+
             state.copy(
                 composeNodeRoot = updatedRoot ?: state.composeNodeRoot,
-                selectedComposeNode = nextSelection
+                selectedComposeNode = resolvedNextSelection
             )
         }
     }
@@ -76,10 +79,15 @@ class ComposeTreeScreenModel : ScreenModel, ComposeTreeBehavior {
                 composeModifier = composeNode.composeModifier.copy(operations = newOperations)
             )
             val updatedRoot = updateNodeRecursive(state.composeNodeRoot, updatedNode)
+            val resolvedSelected = if (state.selectedComposeNode?.id == composeNode.id) {
+                findNodeById(updatedRoot, updatedNode.id)
+            } else {
+                state.selectedComposeNode?.id?.let { findNodeById(updatedRoot, it) }
+            }
 
             state.copy(
                 composeNodeRoot = updatedRoot,
-                selectedComposeNode = if (state.selectedComposeNode?.id == composeNode.id) updatedNode else state.selectedComposeNode
+                selectedComposeNode = resolvedSelected
             )
         }
     }
@@ -131,18 +139,39 @@ class ComposeTreeScreenModel : ScreenModel, ComposeTreeBehavior {
         return currentNode.copy(properties = updatedProps)
     }
 
-    private fun findNextSelection(targetNode: ComposeNode): ComposeNode? {
-        val parent = targetNode.parent ?: return null
-        
+    private fun findNextSelection(root: ComposeNode, targetNode: ComposeNode): ComposeNode? {
+        val parent = findParent(root, targetNode.id) ?: return null
+
         val siblings = parent.children()
         val targetIndex = siblings.indexOfFirst { it.id == targetNode.id }
-        
+        if (targetIndex == -1) return parent
+
         return if (targetIndex > 0) {
             siblings[targetIndex - 1]
         } else if (siblings.size > 1) {
             siblings[targetIndex + 1]
         } else {
             parent
+        }
+    }
+
+    private fun findParent(currentNode: ComposeNode, targetId: String): ComposeNode? {
+        for (child in currentNode.children()) {
+            if (child.id == targetId) {
+                return currentNode
+            }
+            val found = findParent(child, targetId)
+            if (found != null) {
+                return found
+            }
+        }
+        return null
+    }
+
+    private fun findNodeById(currentNode: ComposeNode, nodeId: String): ComposeNode? {
+        if (currentNode.id == nodeId) return currentNode
+        return currentNode.children().firstNotNullOfOrNull { child ->
+            findNodeById(child, nodeId)
         }
     }
 }

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/DeleteChildVisitor.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/DeleteChildVisitor.kt
@@ -1,0 +1,183 @@
+package com.jesusdmedinac.compose.sdui.presentation.screenmodel
+
+import com.jesusdmedinac.jsontocompose.model.ComposeNode
+import com.jesusdmedinac.jsontocompose.model.NodeProperties
+
+class DeleteChildVisitor(
+    private val targetId: String,
+    private val deleteRecursive: (ComposeNode, String) -> ComposeNode?
+) : NodePropertiesVisitor<NodeProperties> {
+
+    override fun visit(props: NodeProperties.ColumnProps) = 
+        props.copy(children = props.children?.mapNotNull { deleteRecursive(it, targetId) })
+
+    override fun visit(props: NodeProperties.RowProps) = 
+        props.copy(children = props.children?.mapNotNull { deleteRecursive(it, targetId) })
+
+    override fun visit(props: NodeProperties.BoxProps) = 
+        props.copy(children = props.children?.mapNotNull { deleteRecursive(it, targetId) })
+
+    override fun visit(props: NodeProperties.NavigationBarProps) = 
+        props.copy(children = props.children?.mapNotNull { deleteRecursive(it, targetId) })
+
+    override fun visit(props: NodeProperties.NavigationRailProps) = props.copy(
+        header = props.header?.let { deleteRecursive(it, targetId) },
+        children = props.children?.mapNotNull { deleteRecursive(it, targetId) }
+    )
+
+    override fun visit(props: NodeProperties.TabRowProps) = 
+        props.copy(children = props.children?.mapNotNull { deleteRecursive(it, targetId) })
+
+    override fun visit(props: NodeProperties.FlowRowProps) = 
+        props.copy(children = props.children?.mapNotNull { deleteRecursive(it, targetId) })
+
+    override fun visit(props: NodeProperties.FlowColumnProps) = 
+        props.copy(children = props.children?.mapNotNull { deleteRecursive(it, targetId) })
+
+    override fun visit(props: NodeProperties.SegmentedButtonRowProps) = 
+        props.copy(children = props.children?.mapNotNull { deleteRecursive(it, targetId) })
+
+    override fun visit(props: NodeProperties.PagerProps) = 
+        props.copy(pages = props.pages?.mapNotNull { deleteRecursive(it, targetId) })
+
+    override fun visit(props: NodeProperties.SearchBarProps) = props.copy(
+        placeholder = props.placeholder?.let { deleteRecursive(it, targetId) },
+        leadingIcon = props.leadingIcon?.let { deleteRecursive(it, targetId) },
+        trailingIcon = props.trailingIcon?.let { deleteRecursive(it, targetId) },
+        children = props.children?.mapNotNull { deleteRecursive(it, targetId) }
+    )
+
+    override fun visit(props: NodeProperties.BottomBarProps) = 
+        props.copy(children = props.children?.mapNotNull { deleteRecursive(it, targetId) })
+
+    override fun visit(props: NodeProperties.ButtonProps) = 
+        props.copy(child = props.child?.let { deleteRecursive(it, targetId) })
+
+    override fun visit(props: NodeProperties.CardProps) = 
+        props.copy(child = props.child?.let { deleteRecursive(it, targetId) })
+
+    override fun visit(props: NodeProperties.OutlinedCardProps) = 
+        props.copy(child = props.child?.let { deleteRecursive(it, targetId) })
+
+    override fun visit(props: NodeProperties.SurfaceProps) = 
+        props.copy(child = props.child?.let { deleteRecursive(it, targetId) })
+
+    override fun visit(props: NodeProperties.ModalBottomSheetProps) = 
+        props.copy(child = props.child?.let { deleteRecursive(it, targetId) })
+
+    override fun visit(props: NodeProperties.NavigationDrawerProps) = props.copy(
+        drawerContent = props.drawerContent?.mapNotNull { deleteRecursive(it, targetId) },
+        child = props.child?.let { deleteRecursive(it, targetId) }
+    )
+
+    override fun visit(props: NodeProperties.ScaffoldProps) = props.copy(
+        topBar = props.topBar?.let { deleteRecursive(it, targetId) },
+        bottomBar = props.bottomBar?.let { deleteRecursive(it, targetId) },
+        child = props.child?.let { deleteRecursive(it, targetId) },
+        floatingActionButton = props.floatingActionButton?.let { deleteRecursive(it, targetId) }
+    )
+
+    override fun visit(props: NodeProperties.FabProps) = 
+        props.copy(icon = props.icon?.let { deleteRecursive(it, targetId) })
+
+    override fun visit(props: NodeProperties.BadgedBoxProps) = props.copy(
+        badge = props.badge?.let { deleteRecursive(it, targetId) },
+        child = props.child?.let { deleteRecursive(it, targetId) }
+    )
+
+    override fun visit(props: NodeProperties.AlertDialogProps) = props.copy(
+        confirmButton = props.confirmButton?.let { deleteRecursive(it, targetId) },
+        dismissButton = props.dismissButton?.let { deleteRecursive(it, targetId) },
+        title = props.title?.let { deleteRecursive(it, targetId) },
+        text = props.text?.let { deleteRecursive(it, targetId) },
+        icon = props.icon?.let { deleteRecursive(it, targetId) }
+    )
+
+    override fun visit(props: NodeProperties.TopAppBarProps) = props.copy(
+        title = props.title?.let { deleteRecursive(it, targetId) },
+        navigationIcon = props.navigationIcon?.let { deleteRecursive(it, targetId) },
+        actions = props.actions?.mapNotNull { deleteRecursive(it, targetId) }
+    )
+
+    override fun visit(props: NodeProperties.ExtendedFabProps) = props.copy(
+        icon = props.icon?.let { deleteRecursive(it, targetId) },
+        text = props.text?.let { deleteRecursive(it, targetId) }
+    )
+
+    override fun visit(props: NodeProperties.TextFieldProps) = props.copy(
+        placeholder = props.placeholder?.let { deleteRecursive(it, targetId) },
+        label = props.label?.let { deleteRecursive(it, targetId) },
+        leadingIcon = props.leadingIcon?.let { deleteRecursive(it, targetId) },
+        trailingIcon = props.trailingIcon?.let { deleteRecursive(it, targetId) },
+        supportingText = props.supportingText?.let { deleteRecursive(it, targetId) },
+        prefix = props.prefix?.let { deleteRecursive(it, targetId) },
+        suffix = props.suffix?.let { deleteRecursive(it, targetId) }
+    )
+
+    override fun visit(props: NodeProperties.ListItemProps) = props.copy(
+        headlineContent = props.headlineContent?.let { deleteRecursive(it, targetId) },
+        supportingContent = props.supportingContent?.let { deleteRecursive(it, targetId) },
+        overlineContent = props.overlineContent?.let { deleteRecursive(it, targetId) },
+        leadingContent = props.leadingContent?.let { deleteRecursive(it, targetId) },
+        trailingContent = props.trailingContent?.let { deleteRecursive(it, targetId) }
+    )
+
+    override fun visit(props: NodeProperties.ChipProps) = props.copy(
+        label = props.label?.let { deleteRecursive(it, targetId) },
+        leadingIcon = props.leadingIcon?.let { deleteRecursive(it, targetId) }
+    )
+
+    override fun visit(props: NodeProperties.FilterChipProps) = props.copy(
+        label = props.label?.let { deleteRecursive(it, targetId) },
+        leadingIcon = props.leadingIcon?.let { deleteRecursive(it, targetId) }
+    )
+
+    override fun visit(props: NodeProperties.InputChipProps) = props.copy(
+        label = props.label?.let { deleteRecursive(it, targetId) },
+        leadingIcon = props.leadingIcon?.let { deleteRecursive(it, targetId) },
+        trailingIcon = props.trailingIcon?.let { deleteRecursive(it, targetId) }
+    )
+
+    override fun visit(props: NodeProperties.PlainTooltipProps) = 
+        props.copy(anchor = props.anchor?.let { deleteRecursive(it, targetId) })
+
+    override fun visit(props: NodeProperties.RichTooltipProps) = props.copy(
+        anchor = props.anchor?.let { deleteRecursive(it, targetId) },
+        title = props.title?.let { deleteRecursive(it, targetId) },
+        text = props.text?.let { deleteRecursive(it, targetId) },
+        action = props.action?.let { deleteRecursive(it, targetId) }
+    )
+
+    override fun visit(props: NodeProperties.NavigationBarItemProps) = props.copy(
+        label = props.label?.let { deleteRecursive(it, targetId) },
+        icon = props.icon?.let { deleteRecursive(it, targetId) }
+    )
+
+    override fun visit(props: NodeProperties.NavigationRailItemProps) = props.copy(
+        label = props.label?.let { deleteRecursive(it, targetId) },
+        icon = props.icon?.let { deleteRecursive(it, targetId) }
+    )
+
+    override fun visit(props: NodeProperties.NavigationDrawerItemProps) = props.copy(
+        label = props.label?.let { deleteRecursive(it, targetId) },
+        icon = props.icon?.let { deleteRecursive(it, targetId) },
+        badge = props.badge?.let { deleteRecursive(it, targetId) }
+    )
+
+    override fun visit(props: NodeProperties.TabProps) = props.copy(
+        text = props.text?.let { deleteRecursive(it, targetId) },
+        icon = props.icon?.let { deleteRecursive(it, targetId) }
+    )
+
+    override fun visit(props: NodeProperties.BottomNavigationItemProps) = props.copy(
+        label = props.label?.let { deleteRecursive(it, targetId) },
+        icon = props.icon?.let { deleteRecursive(it, targetId) }
+    )
+
+    override fun visit(props: NodeProperties.SegmentedButtonProps) = props.copy(
+        label = props.label?.let { deleteRecursive(it, targetId) },
+        icon = props.icon?.let { deleteRecursive(it, targetId) }
+    )
+
+    override fun visitDefault(props: NodeProperties) = props
+}

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/ui/MainScreen.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/ui/MainScreen.kt
@@ -176,7 +176,7 @@ data object MainScreen : Screen {
                         (event.key == Key.Delete || event.key == Key.Backspace)) {
                         
                         if (selectedComposeNode != null && composeTreeState.composeNodeRoot.id != selectedComposeNode.id) {
-                            if (selectedComposeNode.asList().size > 1) {
+                            if (selectedComposeNode.children().isNotEmpty()) {
                                 showDeleteDialog = true
                             } else {
                                 composeTreeScreenModel.deleteNode(selectedComposeNode)

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/ui/MainScreen.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/ui/MainScreen.kt
@@ -16,6 +16,15 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedIconButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.AlertDialog
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.foundation.focusable
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -127,14 +136,65 @@ data object MainScreen : Screen {
         }
 
         // UI Layer
-        MainScreenLayout(
-            composeTreeState = composeTreeState,
-            mainScreenBehavior = mainScreenModel,
-            isLeftPanelDisplayed = mainScreenState.isLeftPanelDisplayed,
-            isRightPanelDisplayed = mainScreenState.isRightPanelDisplayed,
-            onLeftPanelClosed = { mainScreenModel.onDisplayLeftPanelChange(false) },
-            onRightPanelClosed = { mainScreenModel.onDisplayRightPanelChange(false) }
-        )
+        var showDeleteDialog by remember { mutableStateOf(false) }
+        
+        if (showDeleteDialog) {
+            AlertDialog(
+                onDismissRequest = { showDeleteDialog = false },
+                title = { Text("Delete Node") },
+                text = { Text("Are you sure you want to delete this node? All its children will also be deleted.") },
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            if (selectedComposeNode != null) {
+                                composeTreeScreenModel.deleteNode(selectedComposeNode)
+                            }
+                            showDeleteDialog = false
+                        }
+                    ) {
+                        Text("Delete", color = MaterialTheme.colorScheme.error)
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showDeleteDialog = false }) {
+                        Text("Cancel")
+                    }
+                }
+            )
+        }
+
+        val focusRequester = remember { FocusRequester() }
+        LaunchedEffect(Unit) { focusRequester.requestFocus() }
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .focusRequester(focusRequester)
+                .focusable()
+                .onKeyEvent { event ->
+                    if (event.type == KeyEventType.KeyUp && 
+                        (event.key == Key.Delete || event.key == Key.Backspace)) {
+                        
+                        if (selectedComposeNode != null && composeTreeState.composeNodeRoot.id != selectedComposeNode.id) {
+                            if (selectedComposeNode.asList().size > 1) {
+                                showDeleteDialog = true
+                            } else {
+                                composeTreeScreenModel.deleteNode(selectedComposeNode)
+                            }
+                            true
+                        } else false
+                    } else false
+                }
+        ) {
+            MainScreenLayout(
+                composeTreeState = composeTreeState,
+                mainScreenBehavior = mainScreenModel,
+                isLeftPanelDisplayed = mainScreenState.isLeftPanelDisplayed,
+                isRightPanelDisplayed = mainScreenState.isRightPanelDisplayed,
+                onLeftPanelClosed = { mainScreenModel.onDisplayLeftPanelChange(false) },
+                onRightPanelClosed = { mainScreenModel.onDisplayRightPanelChange(false) }
+            )
+        }
     }
 }
 

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/ui/composable/ComposeNodeEditor.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/ui/composable/ComposeNodeEditor.kt
@@ -20,6 +20,8 @@ import androidx.compose.material.IconButton
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedIconButton
 import androidx.compose.runtime.Composable
@@ -43,6 +45,7 @@ import com.composables.icons.lucide.ArrowLeft
 import com.composables.icons.lucide.Delete
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Plus
+import com.jesusdmedinac.compose.sdui.presentation.screenmodel.ComposeTreeScreenModel
 import com.jesusdmedinac.compose.sdui.presentation.screenmodel.EditNodeBehavior
 import com.jesusdmedinac.compose.sdui.presentation.screenmodel.EditNodeScreenModel
 import com.jesusdmedinac.compose.sdui.presentation.screenmodel.EditNodeScreenState
@@ -58,6 +61,10 @@ fun ComposeNodeEditor(
     val navigator = LocalNavigator.currentOrThrow
     val editNodeScreenModel: EditNodeScreenModel = navigator.koinNavigatorScreenModel()
     val editNodeState by editNodeScreenModel.state.collectAsState()
+    val composeTreeScreenModel: ComposeTreeScreenModel = navigator.koinNavigatorScreenModel()
+    val composeTreeState by composeTreeScreenModel.state.collectAsState()
+    
+    var showDeleteDialog by remember { mutableStateOf(false) }
 
     val selectedComposeNode = editNodeState.selectedComposeNode
     val editingComposeNode = editNodeState.editingComposeNode
@@ -68,13 +75,36 @@ fun ComposeNodeEditor(
         )
         return
     }
+    if (showDeleteDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteDialog = false },
+            title = { Text("Delete Node") },
+            text = { Text("Are you sure you want to delete this node? All its children will also be deleted.") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        composeTreeScreenModel.deleteNode(selectedComposeNode)
+                        showDeleteDialog = false
+                    }
+                ) {
+                    Text("Delete", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteDialog = false }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+
     LazyColumn(
         modifier = modifier
     ) {
         item {
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.Start,
+                horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 IconButton(
@@ -90,6 +120,28 @@ fun ComposeNodeEditor(
                         imageVector = Lucide.ArrowLeft,
                         contentDescription = null,
                     )
+                }
+                
+                if (composeTreeState.composeNodeRoot.id != selectedComposeNode.id) {
+                    IconButton(
+                        onClick = {
+                            if (selectedComposeNode.asList().size > 1) {
+                                showDeleteDialog = true
+                            } else {
+                                composeTreeScreenModel.deleteNode(selectedComposeNode)
+                            }
+                        },
+                        modifier = Modifier
+                            .pointerHoverIcon(
+                                icon = PointerIcon.Hand
+                            )
+                    ) {
+                        Icon(
+                            imageVector = Lucide.Delete,
+                            contentDescription = "Delete Node",
+                            tint = MaterialTheme.colorScheme.error
+                        )
+                    }
                 }
             }
         }

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/ui/composable/ComposeNodeEditor.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/ui/composable/ComposeNodeEditor.kt
@@ -125,7 +125,7 @@ fun ComposeNodeEditor(
                 if (composeTreeState.composeNodeRoot.id != selectedComposeNode.id) {
                     IconButton(
                         onClick = {
-                            if (selectedComposeNode.asList().size > 1) {
+                            if (selectedComposeNode.children().isNotEmpty()) {
                                 showDeleteDialog = true
                             } else {
                                 composeTreeScreenModel.deleteNode(selectedComposeNode)

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/ui/composable/ComposeNodeEditor.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/ui/composable/ComposeNodeEditor.kt
@@ -155,7 +155,8 @@ fun ComposeNodeEditor(
         )
         composeModifierFields(
             editNodeState = editNodeState,
-            editNodeBehavior = editNodeScreenModel
+            editNodeBehavior = editNodeScreenModel,
+            composeTreeBehavior = composeTreeScreenModel,
         )
     }
 }
@@ -287,6 +288,7 @@ private fun LazyListScope.composeTextTextField(
 private fun LazyListScope.composeModifierFields(
     editNodeState: EditNodeScreenState,
     editNodeBehavior: EditNodeBehavior,
+    composeTreeBehavior: com.jesusdmedinac.compose.sdui.presentation.screenmodel.ComposeTreeBehavior,
 ) {
     item {
         Text(
@@ -301,6 +303,11 @@ private fun LazyListScope.composeModifierFields(
         operation.ToComposeModifierOperation(
             editNodeBehavior = editNodeBehavior,
             operationIndex = index,
+            onDelete = {
+                editNodeState.editingComposeNode?.let { node ->
+                    composeTreeBehavior.deleteModifier(node, index)
+                }
+            }
         )
     }
 
@@ -361,6 +368,7 @@ private fun ComposeModifier.Operation.ToComposeModifierOperation(
     operationIndex: Int,
     modifier: Modifier = Modifier,
     editNodeBehavior: EditNodeBehavior,
+    onDelete: () -> Unit,
 ) {
     val value = when (this) {
         is ComposeModifier.Operation.BackgroundColor -> this.hexColor
@@ -391,9 +399,7 @@ private fun ComposeModifier.Operation.ToComposeModifierOperation(
         },
         trailingIcon = {
             OutlinedIconButton(
-                onClick = {
-
-                },
+                onClick = onDelete,
                 colors = IconButtonDefaults.outlinedIconButtonColors(
                     contentColor = MaterialTheme.colorScheme.error,
                 ),

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/ui/composable/ComposeNodeTree.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/ui/composable/ComposeNodeTree.kt
@@ -49,7 +49,9 @@ import com.composables.icons.lucide.Lucide
 import com.jesusdmedinac.compose.sdui.presentation.screenmodel.ComposeTreeBehavior
 import com.jesusdmedinac.compose.sdui.presentation.screenmodel.ComposeTreeScreenModel
 import com.jesusdmedinac.compose.sdui.presentation.screenmodel.ComposeTreeState
+import com.jesusdmedinac.compose.sdui.presentation.screenmodel.createDefaultProperties
 import com.jesusdmedinac.jsontocompose.model.ComposeNode
+import com.jesusdmedinac.jsontocompose.model.ComposeType
 
 
 @Composable
@@ -70,7 +72,14 @@ fun ComposeNodeTree(
 @Composable
 private fun ComposeNode.ToComposeTree(
     modifier: Modifier = Modifier,
-    state: ComposeTreeState = ComposeTreeState(),
+    state: ComposeTreeState = ComposeTreeState(
+        composeNodeRoot = ComposeNode(
+            type = ComposeType.Box,
+            properties = ComposeType.Box.createDefaultProperties()
+        ),
+        selectedComposeNode = null,
+        collapsedNodes = emptyList()
+    ),
     behavior: ComposeTreeBehavior = ComposeTreeBehavior.Default,
 ) {
     val horizontalScrollState = rememberScrollState()
@@ -92,7 +101,7 @@ private fun ComposeNode.ToComposeTree(
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun ComposeNode.ComposeTreeItem(
-    state: ComposeTreeState = ComposeTreeState(),
+    state: ComposeTreeState,
     behavior: ComposeTreeBehavior = ComposeTreeBehavior.Default,
     modifier: Modifier = Modifier,
 ) {

--- a/composy/src/commonTest/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/ComposeTreeScreenModelTest.kt
+++ b/composy/src/commonTest/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/ComposeTreeScreenModelTest.kt
@@ -24,10 +24,11 @@ class ComposeTreeScreenModelTest {
         // Add a Text node
         val newTextNode = ComposeNode(
             type = ComposeType.Text,
+            properties = NodeProperties.TextProps(),
             parent = rootNode
         )
         
-        // Verify that default properties were created automatically (non-null)
+        // Verify properties
         val textProps = newTextNode.properties
         assertIs<NodeProperties.TextProps>(textProps)
         
@@ -54,6 +55,7 @@ class ComposeTreeScreenModelTest {
         // 1. Add a Column to the root Box
         val columnNode = ComposeNode(
             type = ComposeType.Column,
+            properties = NodeProperties.ColumnProps(),
             parent = rootNode
         )
         screenModel.onAddNewNodeToChildren(columnNode)
@@ -66,6 +68,7 @@ class ComposeTreeScreenModelTest {
         // 2. Add a Text node to the Column
         val newTextNode = ComposeNode(
             type = ComposeType.Text,
+            properties = NodeProperties.TextProps(),
             parent = addedColumn
         )
         screenModel.onAddNewNodeToChildren(newTextNode)

--- a/docs/projects/phase-2-editor-mvp/PROGRESS.md
+++ b/docs/projects/phase-2-editor-mvp/PROGRESS.md
@@ -1,13 +1,13 @@
 # PROGRESS - Phase 2: Functional Editor (MVP)
 
 ## Feature: Tree Node Deletion
-- [ ] Scenario: Delete a leaf node (Text) from the tree
-- [ ] Scenario: Delete a node with children (Nested Column)
-- [ ] Scenario: Cancel deletion of node with children
-- [ ] Scenario: Delete the last child of a container
-- [ ] Scenario: Root node cannot be deleted
-- [ ] Scenario: Delete node with keyboard shortcut
-- [ ] Scenario: Preview updates after deleting a node
+- [x] Scenario: Delete a leaf node (Text) from the tree
+- [x] Scenario: Delete a node with children (Nested Column)
+- [x] Scenario: Cancel deletion of node with children
+- [x] Scenario: Delete the last child of a container
+- [x] Scenario: Root node cannot be deleted
+- [x] Scenario: Delete node with keyboard shortcut
+- [x] Scenario: Preview updates after deleting a node
 
 ## Feature: Modifier Deletion in Node Editor
 - [ ] Scenario: Delete a modifier from the list

--- a/docs/projects/phase-2-editor-mvp/PROGRESS.md
+++ b/docs/projects/phase-2-editor-mvp/PROGRESS.md
@@ -10,10 +10,10 @@
 - [x] Scenario: Preview updates after deleting a node
 
 ## Feature: Modifier Deletion in Node Editor
-- [ ] Scenario: Delete a modifier from the list
-- [ ] Scenario: Delete the last modifier of a node
-- [ ] Scenario: Delete modifier and verify JSON reflects the change
-- [ ] Scenario: Modifier delete button has visual confirmation
+- [x] Scenario: Delete a modifier from the list
+- [x] Scenario: Delete the last modifier of a node
+- [x] Scenario: Delete modifier and verify JSON reflects the change
+- [x] Scenario: Modifier delete button has visual confirmation
 
 ## Feature: Tree Node Reordering
 - [ ] Scenario: Move node up within the same parent


### PR DESCRIPTION
Closes #39, Closes #44. Refactored tree node deletion using the Visitor Pattern (DeleteChildVisitor) to support all 50+ components. Also implemented modifier deletion with visual confirmation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delete selected nodes via Delete/Backspace, with confirmation for nodes that have children.
  * Delete individual modifier operations from the node editor.

* **Documentation**
  * Updated progress roadmap: Phase 2 and overall completion metrics and checklist statuses now reflect recent progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->