### PR TITLE
feat: tree node reordering

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -14,13 +14,13 @@
 | 2   | [phase-actions-system](#2-phase-actions-system)                   | `library/`    | 37        | 37        | **100%** |
 | 3   | [phase-demo-showcase](#3-phase-demo-showcase)                     | `composeApp/` | 36        | 36        | **100%** |
 | 4   | [phase-3-expand-library](#4-phase-3-expand-library)               | `library/`    | 239       | 239       | **100%** |
-| 5   | [phase-2-editor-mvp](#2-phase-2-editor-mvp)                       | `composy/`    | 58        | 19        | **32%**  |
+| 5   | [phase-2-editor-mvp](#2-phase-2-editor-mvp)                       | `composy/`    | 58        | 27        | **46%**  |
 | 6   | [phase-4-semantics-testability](#3-phase-4-semantics-testability) | `library/`    | 30        | 0         | **0%**   |
 | 7   | [phase-3-differentiators](#4-phase-3-differentiators)             | Multi-module  | 37        | 0         | **0%**   |
-|     | **TOTAL**                                                         |               | **620**   | **518**   | **83%**  |
+|     | **TOTAL**                                                         |               | **620**   | **526**   | **84%**  |
 
 ```text
-Progress: [█████████████████████████████████░░░░░░] 83%
+Progress: [█████████████████████████████████░░░░░░] 84%
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            phase-1 ✅  actions ✅  demo ✅  expand ✅  editor  sem  diff
 ```
@@ -79,7 +79,7 @@ Progress: [███████████████████████
 
 ### 2. phase-2-editor-mvp
 
-**Status:** 🏗️ In Progress (19/58 — 32%)
+**Status:** 🏗️ In Progress (27/58 — 46%)
 **Module:** `composy/`
 **Depends on:** Benefits from phase-3-expand-library.
 

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/ComposeTreeScreenModel.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/ComposeTreeScreenModel.kt
@@ -67,6 +67,32 @@ class ComposeTreeScreenModel : ScreenModel, ComposeTreeBehavior {
         }
     }
 
+    override fun moveNodeUp(composeNode: ComposeNode) {
+        reorderNode(composeNode, ReorderDirection.UP)
+    }
+
+    override fun moveNodeDown(composeNode: ComposeNode) {
+        reorderNode(composeNode, ReorderDirection.DOWN)
+    }
+
+    private fun reorderNode(composeNode: ComposeNode, direction: ReorderDirection) {
+        _state.update { state ->
+            if (state.composeNodeRoot.id == composeNode.id) return@update state
+
+            val parent = findParent(state.composeNodeRoot, composeNode.id) ?: return@update state
+            val visitor = ReorderChildVisitor(composeNode.id, direction)
+            val updatedParentProps = parent.properties.accept(visitor)
+            val updatedParent = parent.copy(properties = updatedParentProps)
+
+            val updatedRoot = updateNodeRecursive(state.composeNodeRoot, updatedParent)
+            
+            state.copy(
+                composeNodeRoot = updatedRoot,
+                selectedComposeNode = findNodeById(updatedRoot, composeNode.id) ?: state.selectedComposeNode
+            )
+        }
+    }
+
     override fun deleteModifier(composeNode: ComposeNode, modifierOperationIndex: Int) {
         _state.update { state ->
             val oldOperations = composeNode.composeModifier.operations
@@ -174,6 +200,35 @@ class ComposeTreeScreenModel : ScreenModel, ComposeTreeBehavior {
             findNodeById(child, nodeId)
         }
     }
+
+    companion object {
+        fun canMoveUp(root: ComposeNode, targetNode: ComposeNode): Boolean {
+            val parent = findParentNode(root, targetNode.id) ?: return false
+            val siblings = parent.children()
+            val index = siblings.indexOfFirst { it.id == targetNode.id }
+            return index > 0
+        }
+
+        fun canMoveDown(root: ComposeNode, targetNode: ComposeNode): Boolean {
+            val parent = findParentNode(root, targetNode.id) ?: return false
+            val siblings = parent.children()
+            val index = siblings.indexOfFirst { it.id == targetNode.id }
+            return index >= 0 && index < siblings.size - 1
+        }
+
+        private fun findParentNode(currentNode: ComposeNode, targetId: String): ComposeNode? {
+            for (child in currentNode.children()) {
+                if (child.id == targetId) {
+                    return currentNode
+                }
+                val found = findParentNode(child, targetId)
+                if (found != null) {
+                    return found
+                }
+            }
+            return null
+        }
+    }
 }
 
 data class ComposeTreeState(
@@ -188,6 +243,14 @@ data class ComposeTreeState(
         val parents = composeNode.parents()
         return parents.none { parent -> collapsedNodes.any { it.id == parent.id } }
     }
+    fun canMoveUp(composeNode: ComposeNode): Boolean {
+        if (composeNodeRoot.id == composeNode.id) return false
+        return ComposeTreeScreenModel.canMoveUp(composeNodeRoot, composeNode)
+    }
+    fun canMoveDown(composeNode: ComposeNode): Boolean {
+        if (composeNodeRoot.id == composeNode.id) return false
+        return ComposeTreeScreenModel.canMoveDown(composeNodeRoot, composeNode)
+    }
 }
 
 interface ComposeTreeBehavior {
@@ -197,6 +260,8 @@ interface ComposeTreeBehavior {
     fun deleteNode(composeNode: ComposeNode)
     fun deleteModifier(composeNode: ComposeNode, modifierOperationIndex: Int)
     fun onNodeExpanded(composeNode: ComposeNode)
+    fun moveNodeUp(composeNode: ComposeNode)
+    fun moveNodeDown(composeNode: ComposeNode)
 
     companion object {
         val Default = object : ComposeTreeBehavior {
@@ -222,6 +287,14 @@ interface ComposeTreeBehavior {
 
             override fun onNodeExpanded(composeNode: ComposeNode) {
                 TODO("onNodeExpanded is not implemented")
+            }
+
+            override fun moveNodeUp(composeNode: ComposeNode) {
+                TODO("moveNodeUp is not implemented")
+            }
+
+            override fun moveNodeDown(composeNode: ComposeNode) {
+                TODO("moveNodeDown is not implemented")
             }
         }
     }

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/ReorderChildVisitor.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/ReorderChildVisitor.kt
@@ -1,0 +1,54 @@
+package com.jesusdmedinac.compose.sdui.presentation.screenmodel
+
+import com.jesusdmedinac.jsontocompose.model.ComposeNode
+import com.jesusdmedinac.jsontocompose.model.NodeProperties
+
+enum class ReorderDirection { UP, DOWN }
+
+class ReorderChildVisitor(
+    private val targetId: String,
+    private val direction: ReorderDirection
+) : NodePropertiesVisitor<NodeProperties> {
+
+    private fun reorder(list: List<ComposeNode>?): List<ComposeNode>? {
+        if (list == null) return null
+        val index = list.indexOfFirst { it.id == targetId }
+        if (index == -1) return list
+
+        val mutableList = list.toMutableList()
+        when (direction) {
+            ReorderDirection.UP -> {
+                if (index > 0) {
+                    val temp = mutableList[index - 1]
+                    mutableList[index - 1] = mutableList[index]
+                    mutableList[index] = temp
+                }
+            }
+            ReorderDirection.DOWN -> {
+                if (index < mutableList.size - 1) {
+                    val temp = mutableList[index + 1]
+                    mutableList[index + 1] = mutableList[index]
+                    mutableList[index] = temp
+                }
+            }
+        }
+        return mutableList.toList()
+    }
+
+    override fun visit(props: NodeProperties.ColumnProps) = props.copy(children = reorder(props.children))
+    override fun visit(props: NodeProperties.RowProps) = props.copy(children = reorder(props.children))
+    override fun visit(props: NodeProperties.BoxProps) = props.copy(children = reorder(props.children))
+    override fun visit(props: NodeProperties.NavigationBarProps) = props.copy(children = reorder(props.children))
+    override fun visit(props: NodeProperties.NavigationRailProps) = props.copy(children = reorder(props.children))
+    override fun visit(props: NodeProperties.TabRowProps) = props.copy(children = reorder(props.children))
+    override fun visit(props: NodeProperties.FlowRowProps) = props.copy(children = reorder(props.children))
+    override fun visit(props: NodeProperties.FlowColumnProps) = props.copy(children = reorder(props.children))
+    override fun visit(props: NodeProperties.SegmentedButtonRowProps) = props.copy(children = reorder(props.children))
+    override fun visit(props: NodeProperties.PagerProps) = props.copy(pages = reorder(props.pages))
+    override fun visit(props: NodeProperties.SearchBarProps) = props.copy(children = reorder(props.children))
+    override fun visit(props: NodeProperties.BottomBarProps) = props.copy(children = reorder(props.children))
+    override fun visit(props: NodeProperties.NavigationDrawerProps) = props.copy(drawerContent = reorder(props.drawerContent))
+    override fun visit(props: NodeProperties.TopAppBarProps) = props.copy(actions = reorder(props.actions))
+
+    override fun visitDefault(props: NodeProperties) = props
+}

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/ui/MainScreen.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/ui/MainScreen.kt
@@ -25,6 +25,8 @@ import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -172,18 +174,34 @@ data object MainScreen : Screen {
                 .focusRequester(focusRequester)
                 .focusable()
                 .onKeyEvent { event ->
-                    if (event.type == KeyEventType.KeyUp && 
-                        (event.key == Key.Delete || event.key == Key.Backspace)) {
-                        
-                        if (selectedComposeNode != null && composeTreeState.composeNodeRoot.id != selectedComposeNode.id) {
-                            if (selectedComposeNode.children().isNotEmpty()) {
-                                showDeleteDialog = true
-                            } else {
-                                composeTreeScreenModel.deleteNode(selectedComposeNode)
+                    if (event.type == KeyEventType.KeyUp) {
+                        if (event.key == Key.Delete || event.key == Key.Backspace) {
+                            if (selectedComposeNode != null && composeTreeState.composeNodeRoot.id != selectedComposeNode.id) {
+                                if (selectedComposeNode.children().isNotEmpty()) {
+                                    showDeleteDialog = true
+                                } else {
+                                    composeTreeScreenModel.deleteNode(selectedComposeNode)
+                                }
+                                return@onKeyEvent true
                             }
-                            true
-                        } else false
-                    } else false
+                        }
+                        
+                        if (event.isCtrlPressed || event.isMetaPressed) {
+                            if (event.key == Key.DirectionUp && selectedComposeNode != null) {
+                                if (composeTreeState.canMoveUp(selectedComposeNode)) {
+                                    composeTreeScreenModel.moveNodeUp(selectedComposeNode)
+                                    return@onKeyEvent true
+                                }
+                            }
+                            if (event.key == Key.DirectionDown && selectedComposeNode != null) {
+                                if (composeTreeState.canMoveDown(selectedComposeNode)) {
+                                    composeTreeScreenModel.moveNodeDown(selectedComposeNode)
+                                    return@onKeyEvent true
+                                }
+                            }
+                        }
+                    }
+                    false
                 }
         ) {
             MainScreenLayout(

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/ui/composable/ComposeNodeEditor.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/ui/composable/ComposeNodeEditor.kt
@@ -42,6 +42,7 @@ import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.composables.icons.lucide.ArrowDown
 import com.composables.icons.lucide.ArrowLeft
+import com.composables.icons.lucide.ArrowUp
 import com.composables.icons.lucide.Delete
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Plus
@@ -122,25 +123,55 @@ fun ComposeNodeEditor(
                     )
                 }
                 
-                if (composeTreeState.composeNodeRoot.id != selectedComposeNode.id) {
-                    IconButton(
-                        onClick = {
-                            if (selectedComposeNode.children().isNotEmpty()) {
-                                showDeleteDialog = true
-                            } else {
-                                composeTreeScreenModel.deleteNode(selectedComposeNode)
-                            }
-                        },
-                        modifier = Modifier
-                            .pointerHoverIcon(
-                                icon = PointerIcon.Hand
+                Row {
+                    if (composeTreeState.canMoveUp(selectedComposeNode)) {
+                        IconButton(
+                            onClick = {
+                                composeTreeScreenModel.moveNodeUp(selectedComposeNode)
+                            },
+                            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)
+                        ) {
+                            Icon(
+                                imageVector = Lucide.ArrowUp,
+                                contentDescription = "Move Node Up"
                             )
-                    ) {
-                        Icon(
-                            imageVector = Lucide.Delete,
-                            contentDescription = "Delete Node",
-                            tint = MaterialTheme.colorScheme.error
-                        )
+                        }
+                    }
+                    
+                    if (composeTreeState.canMoveDown(selectedComposeNode)) {
+                        IconButton(
+                            onClick = {
+                                composeTreeScreenModel.moveNodeDown(selectedComposeNode)
+                            },
+                            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)
+                        ) {
+                            Icon(
+                                imageVector = Lucide.ArrowDown,
+                                contentDescription = "Move Node Down"
+                            )
+                        }
+                    }
+
+                    if (composeTreeState.composeNodeRoot.id != selectedComposeNode.id) {
+                        IconButton(
+                            onClick = {
+                                if (selectedComposeNode.children().isNotEmpty()) {
+                                    showDeleteDialog = true
+                                } else {
+                                    composeTreeScreenModel.deleteNode(selectedComposeNode)
+                                }
+                            },
+                            modifier = Modifier
+                                .pointerHoverIcon(
+                                    icon = PointerIcon.Hand
+                                )
+                        ) {
+                            Icon(
+                                imageVector = Lucide.Delete,
+                                contentDescription = "Delete Node",
+                                tint = MaterialTheme.colorScheme.error
+                            )
+                        }
                     }
                 }
             }

--- a/docs/projects/phase-2-editor-mvp/PROGRESS.md
+++ b/docs/projects/phase-2-editor-mvp/PROGRESS.md
@@ -16,14 +16,14 @@
 - [x] Scenario: Modifier delete button has visual confirmation
 
 ## Feature: Tree Node Reordering
-- [ ] Scenario: Move node up within the same parent
-- [ ] Scenario: Move node down within the same parent
-- [ ] Scenario: Cannot move first node up
-- [ ] Scenario: Cannot move last node down
-- [ ] Scenario: Sibling reordering with hover buttons
-- [ ] Scenario: Sibling reordering with keyboard shortcut
-- [ ] Scenario: Cannot reorder node beyond parent bounds
-- [ ] Scenario: Preview updates when reordering nodes
+- [x] Scenario: Move node up within the same parent
+- [x] Scenario: Move node down within the same parent
+- [x] Scenario: Cannot move first node up
+- [x] Scenario: Cannot move last node down
+- [x] Scenario: Sibling reordering with hover buttons
+- [x] Scenario: Sibling reordering with keyboard shortcut
+- [x] Scenario: Cannot reorder node beyond parent bounds
+- [x] Scenario: Preview updates when reordering nodes
 
 ## Feature: Full Property Panel per Component
 - [ ] Scenario: Edit Text properties


### PR DESCRIPTION
Resolves #40. Implements tree node reordering with UI buttons and keyboard shortcuts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tree node reordering: Compose nodes can now be moved up and down within the editor tree using newly added UI arrow buttons or keyboard shortcuts (Ctrl/Meta + arrow keys). Move controls intelligently enable/disable based on node position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->