### PR TITLE
feat: phase 1.5 mvi architecture planning

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -16,8 +16,8 @@
 | 4   | [phase-3-expand-library](#4-phase-3-expand-library)               | `library/`    | 239       | 239       | **100%** |
 | 5   | [phase-1.5-mvi-architecture](#5-phase-15-mvi-architecture)        | `composy/`    | 12        | 0         | **0%**   |
 | 6   | [phase-2-editor-mvp](#6-phase-2-editor-mvp)                       | `composy/`    | 58        | 19        | **32%**  |
-| 7   | [phase-4-semantics-testability](#7-phase-4-semantics-testability) | `library/`    | 30        | 0         | **0%**   |
-| 8   | [phase-3-differentiators](#8-phase-3-differentiators)             | Multi-module  | 37        | 0         | **0%**   |
+| 7   | [phase-4-semantics-testability](#3-phase-4-semantics-testability) | `library/`    | 30        | 0         | **0%**   |
+| 8   | [phase-3-differentiators](#4-phase-3-differentiators)             | Multi-module  | 37        | 0         | **0%**   |
 |     | **TOTAL**                                                         |               | **632**   | **518**   | **81%**  |
 
 ```text

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -14,10 +14,11 @@
 | 2   | [phase-actions-system](#2-phase-actions-system)                   | `library/`    | 37        | 37        | **100%** |
 | 3   | [phase-demo-showcase](#3-phase-demo-showcase)                     | `composeApp/` | 36        | 36        | **100%** |
 | 4   | [phase-3-expand-library](#4-phase-3-expand-library)               | `library/`    | 239       | 239       | **100%** |
-| 5   | [phase-2-editor-mvp](#2-phase-2-editor-mvp)                       | `composy/`    | 58        | 19        | **32%**  |
-| 6   | [phase-4-semantics-testability](#3-phase-4-semantics-testability) | `library/`    | 30        | 0         | **0%**   |
-| 7   | [phase-3-differentiators](#4-phase-3-differentiators)             | Multi-module  | 37        | 0         | **0%**   |
-|     | **TOTAL**                                                         |               | **620**   | **518**   | **83%**  |
+| 5   | [phase-1.5-mvi-architecture](#5-phase-15-mvi-architecture)        | `composy/`    | 12        | 0         | **0%**   |
+| 6   | [phase-2-editor-mvp](#6-phase-2-editor-mvp)                       | `composy/`    | 58        | 19        | **32%**  |
+| 7   | [phase-4-semantics-testability](#7-phase-4-semantics-testability) | `library/`    | 30        | 0         | **0%**   |
+| 8   | [phase-3-differentiators](#8-phase-3-differentiators)             | Multi-module  | 37        | 0         | **0%**   |
+|     | **TOTAL**                                                         |               | **632**   | **518**   | **81%**  |
 
 ```text
 Progress: [█████████████████████████████████░░░░░░] 83%
@@ -77,7 +78,14 @@ Progress: [███████████████████████
 | Existing Component Properties | 19 | Enhanced Image, Button, Scaffold, Card, AlertDialog, TopAppBar variants | ✅ Done |
 | Advanced Actions | 16 | Navigate, Conditional, Delay, IncrementState, LaunchUrl, CopyToClipboard, UpdateList | ✅ Done |
 
-### 2. phase-2-editor-mvp
+### 5. phase-1.5-mvi-architecture
+
+**Status:** 📝 Planning (0/12 — 0%)
+**Module:** `composy/`
+**Depends on:** Initial Editor MVP work.
+**Description:** Refactors scattered ScreenModels into a centralized MVI architecture (EditorState + EditorIntent) to solve state desynchronization bugs and enable predictable data flow.
+
+### 6. phase-2-editor-mvp
 
 **Status:** 🏗️ In Progress (19/58 — 32%)
 **Module:** `composy/`

--- a/docs/projects/phase-1.5-mvi-architecture/PROGRESS.md
+++ b/docs/projects/phase-1.5-mvi-architecture/PROGRESS.md
@@ -1,0 +1,23 @@
+# Phase 1.5: MVI Architecture Refactoring
+
+This phase focuses on migrating the scattered ScreenModels to a single, unidirectional data flow (MVI) architecture using a centralized `EditorState` and `EditorIntent`.
+
+## Feature: MVI Architecture Foundation
+- [ ] Scenario: Define central EditorState
+- [ ] Scenario: Define EditorIntent hierarchy
+- [ ] Scenario: Create central EditorScreenModel
+
+## Feature: MVI Tree Operations
+- [ ] Scenario: Migrate Add Node
+- [ ] Scenario: Migrate Delete Node
+- [ ] Scenario: Migrate Reorder Node
+
+## Feature: MVI Editor Operations
+- [ ] Scenario: Migrate Update Node Type
+- [ ] Scenario: Migrate Update Node Text
+- [ ] Scenario: Migrate Modifiers CRUD
+
+## Feature: MVI UI State
+- [ ] Scenario: Migrate Panel Display toggles
+- [ ] Scenario: Migrate Viewport Modes
+- [ ] Scenario: Migrate Keyword Search

--- a/docs/projects/phase-1.5-mvi-architecture/README.md
+++ b/docs/projects/phase-1.5-mvi-architecture/README.md
@@ -38,7 +38,7 @@ sealed interface EditorIntent {
     // Modifier CRUD...
 
     // UI Actions
-    data class ToggleLeftPanel(val displayed: Boolean) : EditorIntent
+    data class SetLeftPanelDisplayed(val displayed: Boolean) : EditorIntent
     // Viewport Mode changes...
 }
 ```

--- a/docs/projects/phase-1.5-mvi-architecture/README.md
+++ b/docs/projects/phase-1.5-mvi-architecture/README.md
@@ -1,0 +1,54 @@
+# Phase 1.5: MVI Architecture Refactoring
+
+## Overview
+Currently, `composy` utilizes multiple `ScreenModel`s (`EditNodeScreenModel`, `ComposeTreeScreenModel`, `ComposeComponentsScreenModel`, `MainScreenModel`), each managing their own `StateFlow`. This distributed state can lead to synchronization bugs (e.g. `selectedComposeNode` getting stale or UI panels disjointed from the core node data).
+
+This phase (`phase-1.5-mvi-architecture`) will centralize the application state into a strict Unidirectional Data Flow pattern (MVI). The objective is to establish a solid, bug-free foundation before continuing with the Editor MVP (Phase 2).
+
+## Architecture
+
+We will create a central `EditorState` and `EditorIntent` to model the entire UI state and all possible user interactions.
+
+### `EditorState`
+A single data class acting as the definitive source of truth:
+```kotlin
+data class EditorState(
+    val rootNode: ComposeNode,
+    val selectedNodeId: String?,
+    val isLeftPanelDisplayed: Boolean,
+    val isRightPanelDisplayed: Boolean,
+    val keyword: String,
+    val viewportMode: ViewportMode
+)
+```
+
+### `EditorIntent`
+A sealed interface capturing all user actions:
+```kotlin
+sealed interface EditorIntent {
+    // Tree Actions
+    data class SelectNode(val id: String?) : EditorIntent
+    data class AddNode(val parentId: String, val type: ComposeType) : EditorIntent
+    data class DeleteNode(val id: String) : EditorIntent
+    data class ReorderNode(val id: String, val direction: ReorderDirection) : EditorIntent
+    
+    // Editor Actions
+    data class UpdateNodeType(val id: String, val type: ComposeType) : EditorIntent
+    data class UpdateNodeText(val id: String, val text: String) : EditorIntent
+    // Modifier CRUD...
+
+    // UI Actions
+    data class ToggleLeftPanel(val displayed: Boolean) : EditorIntent
+    // Viewport Mode changes...
+}
+```
+
+## Features
+
+This phase is broken down into 4 main features, detailed in the `features/` directory:
+1. **MVI Architecture Foundation**: Base classes and the new central ScreenModel.
+2. **MVI Tree Operations**: Migrating operations like Add, Delete, and Reorder.
+3. **MVI Editor Operations**: Migrating properties mapping and modifiers.
+4. **MVI UI State**: Viewports, panels, and keyword filtering.
+
+Please refer to `PROGRESS.md` to track scenario completion.

--- a/docs/projects/phase-1.5-mvi-architecture/features/mvi_editor_operations.feature
+++ b/docs/projects/phase-1.5-mvi-architecture/features/mvi_editor_operations.feature
@@ -1,0 +1,19 @@
+Feature: MVI Editor Operations
+  As a developer
+  I want to handle node property and modifier edits through Intents
+  So that modifying a node safely produces a new root tree state
+
+  Scenario: Migrate Update Node Type
+    Given a selected node
+    When the UpdateNodeType intent is dispatched
+    Then the EditorState should update the root node, mapping properties properly
+
+  Scenario: Migrate Update Node Text
+    Given a selected text node
+    When the UpdateNodeText intent is dispatched
+    Then the EditorState should update the root node with the new text
+
+  Scenario: Migrate Modifiers CRUD
+    Given a selected node
+    When AddModifier, UpdateModifier, or DeleteModifier intents are dispatched
+    Then the EditorState should update the root node's modifiers accordingly

--- a/docs/projects/phase-1.5-mvi-architecture/features/mvi_foundation.feature
+++ b/docs/projects/phase-1.5-mvi-architecture/features/mvi_foundation.feature
@@ -1,0 +1,20 @@
+Feature: MVI Architecture Foundation
+  As a developer
+  I want a centralized MVI architecture
+  So that the editor UI state is predictable, debuggable, and has a single source of truth
+
+  Scenario: Define central EditorState
+    Given the current scattered state in multiple ScreenModels
+    When the MVI refactor begins
+    Then a single EditorState data class should exist holding root node, selection, and UI panels status
+
+  Scenario: Define EditorIntent hierarchy
+    Given the need to model all user actions
+    When the MVI foundation is created
+    Then a sealed interface EditorIntent should exist defining all user actions (Tree, Editor, UI)
+
+  Scenario: Create central EditorScreenModel
+    Given the central EditorState and EditorIntent
+    When the EditorScreenModel is implemented
+    Then it should expose a single StateFlow of EditorState
+    And provide a single `onIntent(intent: EditorIntent)` method for state reduction

--- a/docs/projects/phase-1.5-mvi-architecture/features/mvi_tree_operations.feature
+++ b/docs/projects/phase-1.5-mvi-architecture/features/mvi_tree_operations.feature
@@ -1,0 +1,21 @@
+Feature: MVI Tree Operations
+  As a developer
+  I want to handle node tree manipulations through Intents
+  So that adding, deleting, and reordering nodes is predictable
+
+  Scenario: Migrate Add Node
+    Given a selected node ID
+    When the AddNode intent is dispatched with a new ComposeType
+    Then the EditorState should update its root node with the new child safely inserted
+    And the tree should reflect the changes
+
+  Scenario: Migrate Delete Node
+    Given a node selected in the tree
+    When the DeleteNode intent is dispatched
+    Then the node and its children should be removed from the EditorState root node
+    And the selected node ID should be cleared
+
+  Scenario: Migrate Reorder Node
+    Given a node with siblings
+    When the ReorderNode intent is dispatched with UP or DOWN direction
+    Then the EditorState should update its root node swapping the elements

--- a/docs/projects/phase-1.5-mvi-architecture/features/mvi_ui_state.feature
+++ b/docs/projects/phase-1.5-mvi-architecture/features/mvi_ui_state.feature
@@ -1,0 +1,19 @@
+Feature: MVI UI State
+  As a developer
+  I want to handle UI interactions (panels, viewports, search) through Intents
+  So that the UI layout is strictly driven by EditorState
+
+  Scenario: Migrate Panel Display toggles
+    Given the left and right panels
+    When SetLeftPanelDisplayed or SetRightPanelDisplayed intents are dispatched
+    Then the EditorState boolean flags should update
+
+  Scenario: Migrate Viewport Modes
+    Given the device preview
+    When SetViewportMode intent is dispatched
+    Then the EditorState should update its viewport enum
+
+  Scenario: Migrate Keyword Search
+    Given the components drawer
+    When SetKeyword intent is dispatched
+    Then the EditorState should filter the displayed types based on the keyword


### PR DESCRIPTION
Sets up the README, Gherkin features, and PROGRESS tracker for Phase 1.5 MVI Architecture Refactor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Phase 1.5 planning and README describing a move to a centralized MVI-style editor model with detailed migration workstreams.
  * Added feature specifications covering editor operations, tree operations, and UI state scenarios.
  * Updated project roadmap and progress table to include the new Phase 1.5 planning phase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->