### PR TITLE
feat: migrate node operations to MVI

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -10,9 +10,9 @@
 
 | #   | Phase                                                             | Module        | Scenarios | Completed | Progress |
 | --- | ----------------------------------------------------------------- | ------------- | --------- | --------- | -------- |
-| 1   | [phase-1-solidify-library](#1-phase-1-solidify-library)           | `library/`    | 187       | 187       | **100%** |
-| 2   | [phase-actions-system](#2-phase-actions-system)                   | `library/`    | 37        | 37        | **100%** |
-| 3   | [phase-demo-showcase](#3-phase-demo-showcase)                     | `composeApp/` | 36        | 36        | **100%** |
+| 1   | phase-1-solidify-library                                          | `library/`    | 187       | 187       | **100%** |
+| 2   | phase-actions-system                                              | `library/`    | 37        | 37        | **100%** |
+| 3   | phase-demo-showcase                                               | `composeApp/` | 36        | 36        | **100%** |
 | 4   | [phase-3-expand-library](#phase-3-expand-library)               | `library/`    | 239       | 239       | **100%** |
 | 5   | [phase-1.5-mvi-architecture](#phase-15-mvi-architecture)        | `composy/`    | 12        | 9         | **75%**  |
 | 6   | [phase-2-editor-mvp](#phase-2-editor-mvp)                       | `composy/`    | 58        | 19        | **32%**  |
@@ -24,20 +24,6 @@
 Progress: [█████████████████████████████████░░░░░░] 83%
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            phase-1 ✅  actions ✅  demo ✅  expand ✅  editor  sem  diff
-```
-
----
-...
-
-## Recommended Development Order
-
-### 1. phase-3-expand-library
-
-**Status:** 🏗️ In Progress (143/239 — 60%)
-  │
-  └── phase-4-semantics-testability
-        │
-  ──────┴── phase-3-differentiators
 ```
 
 ---

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -14,14 +14,14 @@
 | 2   | [phase-actions-system](#2-phase-actions-system)                   | `library/`    | 37        | 37        | **100%** |
 | 3   | [phase-demo-showcase](#3-phase-demo-showcase)                     | `composeApp/` | 36        | 36        | **100%** |
 | 4   | [phase-3-expand-library](#phase-3-expand-library)               | `library/`    | 239       | 239       | **100%** |
-| 5   | [phase-1.5-mvi-architecture](#phase-15-mvi-architecture)        | `composy/`    | 12        | 6         | **50%**  |
+| 5   | [phase-1.5-mvi-architecture](#phase-15-mvi-architecture)        | `composy/`    | 12        | 9         | **75%**  |
 | 6   | [phase-2-editor-mvp](#phase-2-editor-mvp)                       | `composy/`    | 58        | 19        | **32%**  |
 | 7   | [phase-4-semantics-testability](#phase-4-semantics-testability) | `library/`    | 30        | 0         | **0%**   |
 | 8   | [phase-3-differentiators](#phase-3-differentiators)             | Multi-module  | 37        | 0         | **0%**   |
-|     | **TOTAL**                                                         |               | **632**   | **524**   | **82%**  |
+|     | **TOTAL**                                                         |               | **632**   | **527**   | **83%**  |
 
 ```text
-Progress: [█████████████████████████████████░░░░░░] 82%
+Progress: [█████████████████████████████████░░░░░░] 83%
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            phase-1 ✅  actions ✅  demo ✅  expand ✅  editor  sem  diff
 ```
@@ -80,7 +80,7 @@ Progress: [███████████████████████
 
 ### phase-1.5-mvi-architecture
 
-**Status:** 🏗️ In Progress (6/12 — 50%)
+**Status:** 🏗️ In Progress (9/12 — 75%)
 **Module:** `composy/`
 **Depends on:** Initial Editor MVP work.
 **Description:** Refactors scattered ScreenModels into a centralized MVI architecture (EditorState + EditorIntent) to solve state desynchronization bugs and enable predictable data flow.

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/ComposeNodeUtils.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/ComposeNodeUtils.kt
@@ -50,3 +50,31 @@ fun ComposeNode.nodeExists(targetId: String): Boolean {
     if (this.id == targetId) return true
     return this.children().any { it.nodeExists(targetId) }
 }
+
+/**
+ * Traverses the tree and applies [transform] to the node with [targetId].
+ */
+fun ComposeNode.updateNodeRecursive(targetId: String, transform: (ComposeNode) -> ComposeNode): ComposeNode {
+    if (this.id == targetId) return transform(this)
+    val newProps = when (val props = this.properties) {
+        is com.jesusdmedinac.jsontocompose.model.NodeProperties.ColumnProps -> props.copy(children = props.children?.map { it.updateNodeRecursive(targetId, transform) })
+        is com.jesusdmedinac.jsontocompose.model.NodeProperties.RowProps -> props.copy(children = props.children?.map { it.updateNodeRecursive(targetId, transform) })
+        is com.jesusdmedinac.jsontocompose.model.NodeProperties.BoxProps -> props.copy(children = props.children?.map { it.updateNodeRecursive(targetId, transform) })
+        is com.jesusdmedinac.jsontocompose.model.NodeProperties.ButtonProps -> props.copy(child = props.child?.updateNodeRecursive(targetId, transform))
+        is com.jesusdmedinac.jsontocompose.model.NodeProperties.ScaffoldProps -> props.copy(child = props.child?.updateNodeRecursive(targetId, transform))
+        is com.jesusdmedinac.jsontocompose.model.NodeProperties.CardProps -> props.copy(child = props.child?.updateNodeRecursive(targetId, transform))
+        is com.jesusdmedinac.jsontocompose.model.NodeProperties.OutlinedCardProps -> props.copy(child = props.child?.updateNodeRecursive(targetId, transform))
+        is com.jesusdmedinac.jsontocompose.model.NodeProperties.TabRowProps -> props.copy(children = props.children?.map { it.updateNodeRecursive(targetId, transform) })
+        is com.jesusdmedinac.jsontocompose.model.NodeProperties.TabProps -> props.copy(
+            text = props.text?.updateNodeRecursive(targetId, transform),
+            icon = props.icon?.updateNodeRecursive(targetId, transform)
+        )
+        is com.jesusdmedinac.jsontocompose.model.NodeProperties.BottomBarProps -> props.copy(children = props.children?.map { it.updateNodeRecursive(targetId, transform) })
+        is com.jesusdmedinac.jsontocompose.model.NodeProperties.FlowRowProps -> props.copy(children = props.children?.map { it.updateNodeRecursive(targetId, transform) })
+        is com.jesusdmedinac.jsontocompose.model.NodeProperties.FlowColumnProps -> props.copy(children = props.children?.map { it.updateNodeRecursive(targetId, transform) })
+        is com.jesusdmedinac.jsontocompose.model.NodeProperties.SurfaceProps -> props.copy(child = props.child?.updateNodeRecursive(targetId, transform))
+        is com.jesusdmedinac.jsontocompose.model.NodeProperties.FabProps -> props.copy(icon = props.icon?.updateNodeRecursive(targetId, transform))
+        else -> props
+    }
+    return this.copy(properties = newProps)
+}

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/ComposeNodeUtils.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/ComposeNodeUtils.kt
@@ -53,9 +53,16 @@ fun ComposeNode.nodeExists(targetId: String): Boolean {
 
 /**
  * Traverses the tree and applies [transform] to the node with [targetId].
+ * Subtrees that do not contain the target are returned as-is (structural sharing),
+ * so only the path from the root to the target is reallocated.
  */
 fun ComposeNode.updateNodeRecursive(targetId: String, transform: (ComposeNode) -> ComposeNode): ComposeNode {
     if (this.id == targetId) return transform(this)
-    val newProps = this.properties.mapChildren { it.updateNodeRecursive(targetId, transform) }
-    return this.copy(properties = newProps)
+    var changed = false
+    val newProps = this.properties.mapChildren { child ->
+        val updated = child.updateNodeRecursive(targetId, transform)
+        if (updated !== child) changed = true
+        updated
+    }
+    return if (changed) this.copy(properties = newProps) else this
 }

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/ComposeNodeUtils.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/ComposeNodeUtils.kt
@@ -56,25 +56,6 @@ fun ComposeNode.nodeExists(targetId: String): Boolean {
  */
 fun ComposeNode.updateNodeRecursive(targetId: String, transform: (ComposeNode) -> ComposeNode): ComposeNode {
     if (this.id == targetId) return transform(this)
-    val newProps = when (val props = this.properties) {
-        is com.jesusdmedinac.jsontocompose.model.NodeProperties.ColumnProps -> props.copy(children = props.children?.map { it.updateNodeRecursive(targetId, transform) })
-        is com.jesusdmedinac.jsontocompose.model.NodeProperties.RowProps -> props.copy(children = props.children?.map { it.updateNodeRecursive(targetId, transform) })
-        is com.jesusdmedinac.jsontocompose.model.NodeProperties.BoxProps -> props.copy(children = props.children?.map { it.updateNodeRecursive(targetId, transform) })
-        is com.jesusdmedinac.jsontocompose.model.NodeProperties.ButtonProps -> props.copy(child = props.child?.updateNodeRecursive(targetId, transform))
-        is com.jesusdmedinac.jsontocompose.model.NodeProperties.ScaffoldProps -> props.copy(child = props.child?.updateNodeRecursive(targetId, transform))
-        is com.jesusdmedinac.jsontocompose.model.NodeProperties.CardProps -> props.copy(child = props.child?.updateNodeRecursive(targetId, transform))
-        is com.jesusdmedinac.jsontocompose.model.NodeProperties.OutlinedCardProps -> props.copy(child = props.child?.updateNodeRecursive(targetId, transform))
-        is com.jesusdmedinac.jsontocompose.model.NodeProperties.TabRowProps -> props.copy(children = props.children?.map { it.updateNodeRecursive(targetId, transform) })
-        is com.jesusdmedinac.jsontocompose.model.NodeProperties.TabProps -> props.copy(
-            text = props.text?.updateNodeRecursive(targetId, transform),
-            icon = props.icon?.updateNodeRecursive(targetId, transform)
-        )
-        is com.jesusdmedinac.jsontocompose.model.NodeProperties.BottomBarProps -> props.copy(children = props.children?.map { it.updateNodeRecursive(targetId, transform) })
-        is com.jesusdmedinac.jsontocompose.model.NodeProperties.FlowRowProps -> props.copy(children = props.children?.map { it.updateNodeRecursive(targetId, transform) })
-        is com.jesusdmedinac.jsontocompose.model.NodeProperties.FlowColumnProps -> props.copy(children = props.children?.map { it.updateNodeRecursive(targetId, transform) })
-        is com.jesusdmedinac.jsontocompose.model.NodeProperties.SurfaceProps -> props.copy(child = props.child?.updateNodeRecursive(targetId, transform))
-        is com.jesusdmedinac.jsontocompose.model.NodeProperties.FabProps -> props.copy(icon = props.icon?.updateNodeRecursive(targetId, transform))
-        else -> props
-    }
+    val newProps = this.properties.mapChildren { it.updateNodeRecursive(targetId, transform) }
     return this.copy(properties = newProps)
 }

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/ComposeNodeUtils.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/ComposeNodeUtils.kt
@@ -1,6 +1,7 @@
 package com.jesusdmedinac.compose.sdui.presentation.screenmodel
 
 import com.jesusdmedinac.jsontocompose.model.ComposeNode
+import com.jesusdmedinac.jsontocompose.model.ComposeType
 
 /**
  * Traverses the tree and inserts the [child] into the node with [parentId].
@@ -49,6 +50,21 @@ fun ComposeNode.reorderNodeRecursive(targetId: String, direction: EditorIntent.R
 fun ComposeNode.nodeExists(targetId: String): Boolean {
     if (this.id == targetId) return true
     return this.children().any { it.nodeExists(targetId) }
+}
+
+/**
+ * Returns the list of types this node can safely be converted to, based on the
+ * children it currently holds: nodes with multiple children can only become
+ * multi-child layouts, nodes with one child can also become single-child
+ * containers, and childless nodes can become anything.
+ */
+fun ComposeNode.compatibleTypes(): List<ComposeType> {
+    val childCount = children().size
+    return when {
+        childCount > 1 -> ComposeType.entries.filter { it.isLayout() }
+        childCount == 1 -> ComposeType.entries.filter { it.isLayout() || it.hasChild() }
+        else -> ComposeType.entries
+    }
 }
 
 /**

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/ComposeTypeExtensions.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/ComposeTypeExtensions.kt
@@ -71,15 +71,20 @@ import com.jesusdmedinac.jsontocompose.model.ComposeType.TimePicker
 import com.jesusdmedinac.jsontocompose.model.ComposeType.TopAppBar
 import com.jesusdmedinac.jsontocompose.model.ComposeType.VerticalDivider
 import com.jesusdmedinac.jsontocompose.model.ComposeType.VerticalPager
+import com.jesusdmedinac.jsontocompose.model.ComposeNode
 import com.jesusdmedinac.jsontocompose.model.NodeProperties
 
 /**
  * Creates a default, non-null properties instance for this component type.
+ * Optionally preserves existing children when changing a node's type.
  */
-fun ComposeType.createDefaultProperties(): NodeProperties = when (this) {
-    Column, LazyColumn -> NodeProperties.ColumnProps()
-    Row, LazyRow -> NodeProperties.RowProps()
-    Box -> NodeProperties.BoxProps()
+fun ComposeType.createDefaultProperties(
+    preservedChildren: List<ComposeNode>? = null,
+    preservedChild: ComposeNode? = null
+): NodeProperties = when (this) {
+    Column, LazyColumn -> NodeProperties.ColumnProps(children = preservedChildren)
+    Row, LazyRow -> NodeProperties.RowProps(children = preservedChildren)
+    Box -> NodeProperties.BoxProps(children = preservedChildren)
     Spacer -> NodeProperties.SpacerProps
     Text -> NodeProperties.TextProps(
         text = "Text"
@@ -87,14 +92,14 @@ fun ComposeType.createDefaultProperties(): NodeProperties = when (this) {
     Icon -> NodeProperties.IconProps(
         iconName = "Add"
     )
-    Button, OutlinedButton, TextButton, ElevatedButton, FilledTonalButton, IconButton -> NodeProperties.ButtonProps()
-    FloatingActionButton -> NodeProperties.FabProps()
+    Button, OutlinedButton, TextButton, ElevatedButton, FilledTonalButton, IconButton -> NodeProperties.ButtonProps(child = preservedChild ?: preservedChildren?.firstOrNull())
+    FloatingActionButton -> NodeProperties.FabProps(icon = preservedChild ?: preservedChildren?.firstOrNull())
     ExtendedFloatingActionButton -> NodeProperties.ExtendedFabProps()
     Image -> NodeProperties.ImageProps()
     TextField, OutlinedTextField -> NodeProperties.TextFieldProps()
-    Scaffold -> NodeProperties.ScaffoldProps()
-    Card, ElevatedCard -> NodeProperties.CardProps()
-    OutlinedCard -> NodeProperties.OutlinedCardProps()
+    Scaffold -> NodeProperties.ScaffoldProps(child = preservedChild ?: preservedChildren?.firstOrNull())
+    Card, ElevatedCard -> NodeProperties.CardProps(child = preservedChild ?: preservedChildren?.firstOrNull())
+    OutlinedCard -> NodeProperties.OutlinedCardProps(child = preservedChild ?: preservedChildren?.firstOrNull())
     AlertDialog -> NodeProperties.AlertDialogProps()
     TopAppBar, CenterAlignedTopAppBar, MediumTopAppBar, LargeTopAppBar -> NodeProperties.TopAppBarProps()
     NavigationBar -> NodeProperties.NavigationBarProps()
@@ -103,23 +108,23 @@ fun ComposeType.createDefaultProperties(): NodeProperties = when (this) {
     NavigationRailItem -> NodeProperties.NavigationRailItemProps()
     ModalNavigationDrawer -> NodeProperties.NavigationDrawerProps()
     NavigationDrawerItem -> NodeProperties.NavigationDrawerItemProps()
-    TabRow, ScrollableTabRow -> NodeProperties.TabRowProps()
-    Tab -> NodeProperties.TabProps()
-    BottomBar -> NodeProperties.BottomBarProps()
+    TabRow, ScrollableTabRow -> NodeProperties.TabRowProps(children = preservedChildren)
+    Tab -> NodeProperties.TabProps(text = preservedChild ?: preservedChildren?.firstOrNull())
+    BottomBar -> NodeProperties.BottomBarProps(children = preservedChildren)
     BottomNavigationItem -> NodeProperties.BottomNavigationItemProps()
-    Switch -> NodeProperties.SwitchProps()
-    Checkbox -> NodeProperties.CheckboxProps()
-    Slider -> NodeProperties.SliderProps()
-    RadioButton -> NodeProperties.RadioButtonProps()
+    Switch -> NodeProperties.SwitchProps(checked = false)
+    Checkbox -> NodeProperties.CheckboxProps(checked = false)
+    Slider -> NodeProperties.SliderProps(value = 0f)
+    RadioButton -> NodeProperties.RadioButtonProps(selected = false)
     SingleChoiceSegmentedButtonRow, MultiChoiceSegmentedButtonRow -> NodeProperties.SegmentedButtonRowProps()
     SegmentedButton -> NodeProperties.SegmentedButtonProps()
     DatePicker -> NodeProperties.DatePickerProps()
     TimePicker -> NodeProperties.TimePickerProps()
     SearchBar -> NodeProperties.SearchBarProps()
     HorizontalDivider, VerticalDivider -> NodeProperties.DividerProps()
-    FlowRow -> NodeProperties.FlowRowProps()
-    FlowColumn -> NodeProperties.FlowColumnProps()
-    Surface -> NodeProperties.SurfaceProps()
+    FlowRow -> NodeProperties.FlowRowProps(children = preservedChildren)
+    FlowColumn -> NodeProperties.FlowColumnProps(children = preservedChildren)
+    Surface -> NodeProperties.SurfaceProps(child = preservedChild ?: preservedChildren?.firstOrNull())
     HorizontalPager, VerticalPager -> NodeProperties.PagerProps()
     ModalBottomSheet -> NodeProperties.ModalBottomSheetProps()
     Badge -> NodeProperties.BadgeProps()

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/ComposeTypeExtensions.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/ComposeTypeExtensions.kt
@@ -79,8 +79,7 @@ import com.jesusdmedinac.jsontocompose.model.NodeProperties
  * Optionally preserves existing children when changing a node's type.
  */
 fun ComposeType.createDefaultProperties(
-    preservedChildren: List<ComposeNode>? = null,
-    preservedChild: ComposeNode? = null
+    preservedChildren: List<ComposeNode>? = null
 ): NodeProperties = when (this) {
     Column, LazyColumn -> NodeProperties.ColumnProps(children = preservedChildren)
     Row, LazyRow -> NodeProperties.RowProps(children = preservedChildren)
@@ -92,14 +91,14 @@ fun ComposeType.createDefaultProperties(
     Icon -> NodeProperties.IconProps(
         iconName = "Add"
     )
-    Button, OutlinedButton, TextButton, ElevatedButton, FilledTonalButton, IconButton -> NodeProperties.ButtonProps(child = preservedChild ?: preservedChildren?.firstOrNull())
-    FloatingActionButton -> NodeProperties.FabProps(icon = preservedChild ?: preservedChildren?.firstOrNull())
+    Button, OutlinedButton, TextButton, ElevatedButton, FilledTonalButton, IconButton -> NodeProperties.ButtonProps(child = preservedChildren?.firstOrNull())
+    FloatingActionButton -> NodeProperties.FabProps(icon = preservedChildren?.firstOrNull())
     ExtendedFloatingActionButton -> NodeProperties.ExtendedFabProps()
     Image -> NodeProperties.ImageProps()
     TextField, OutlinedTextField -> NodeProperties.TextFieldProps()
-    Scaffold -> NodeProperties.ScaffoldProps(child = preservedChild ?: preservedChildren?.firstOrNull())
-    Card, ElevatedCard -> NodeProperties.CardProps(child = preservedChild ?: preservedChildren?.firstOrNull())
-    OutlinedCard -> NodeProperties.OutlinedCardProps(child = preservedChild ?: preservedChildren?.firstOrNull())
+    Scaffold -> NodeProperties.ScaffoldProps(child = preservedChildren?.firstOrNull())
+    Card, ElevatedCard -> NodeProperties.CardProps(child = preservedChildren?.firstOrNull())
+    OutlinedCard -> NodeProperties.OutlinedCardProps(child = preservedChildren?.firstOrNull())
     AlertDialog -> NodeProperties.AlertDialogProps()
     TopAppBar, CenterAlignedTopAppBar, MediumTopAppBar, LargeTopAppBar -> NodeProperties.TopAppBarProps()
     NavigationBar -> NodeProperties.NavigationBarProps()
@@ -109,7 +108,7 @@ fun ComposeType.createDefaultProperties(
     ModalNavigationDrawer -> NodeProperties.NavigationDrawerProps()
     NavigationDrawerItem -> NodeProperties.NavigationDrawerItemProps()
     TabRow, ScrollableTabRow -> NodeProperties.TabRowProps(children = preservedChildren)
-    Tab -> NodeProperties.TabProps(text = preservedChild ?: preservedChildren?.firstOrNull())
+    Tab -> NodeProperties.TabProps(text = preservedChildren?.firstOrNull())
     BottomBar -> NodeProperties.BottomBarProps(children = preservedChildren)
     BottomNavigationItem -> NodeProperties.BottomNavigationItemProps()
     Switch -> NodeProperties.SwitchProps(checked = false)
@@ -124,7 +123,7 @@ fun ComposeType.createDefaultProperties(
     HorizontalDivider, VerticalDivider -> NodeProperties.DividerProps()
     FlowRow -> NodeProperties.FlowRowProps(children = preservedChildren)
     FlowColumn -> NodeProperties.FlowColumnProps(children = preservedChildren)
-    Surface -> NodeProperties.SurfaceProps(child = preservedChild ?: preservedChildren?.firstOrNull())
+    Surface -> NodeProperties.SurfaceProps(child = preservedChildren?.firstOrNull())
     HorizontalPager, VerticalPager -> NodeProperties.PagerProps()
     ModalBottomSheet -> NodeProperties.ModalBottomSheetProps()
     Badge -> NodeProperties.BadgeProps()

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/EditorScreenModel.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/EditorScreenModel.kt
@@ -66,12 +66,11 @@ class EditorScreenModel : ScreenModel, EditorIntent.Visitor {
     override fun visit(intent: EditorIntent.UpdateNodeType) {
         reduce { state ->
             val updatedRoot = state.rootNode.updateNodeRecursive(intent.id) { node ->
-                if (!node.type.compatibleTypes().contains(intent.type)) return@updateNodeRecursive node
+                if (intent.type !in node.compatibleTypes()) return@updateNodeRecursive node
                 node.copy(
                     type = intent.type,
                     properties = intent.type.createDefaultProperties(
-                        preservedChildren = node.children().takeIf { it.isNotEmpty() },
-                        preservedChild = node.children().firstOrNull()
+                        preservedChildren = node.children().takeIf { it.isNotEmpty() }
                     )
                 )
             }
@@ -82,11 +81,9 @@ class EditorScreenModel : ScreenModel, EditorIntent.Visitor {
     override fun visit(intent: EditorIntent.UpdateNodeText) {
         reduce { state ->
             val updatedRoot = state.rootNode.updateNodeRecursive(intent.id) { node ->
-                val newProps = when (val props = node.properties) {
-                    is com.jesusdmedinac.jsontocompose.model.NodeProperties.TextProps -> props.copy(text = intent.text)
-                    else -> props
-                }
-                node.copy(properties = newProps)
+                val props = node.properties
+                if (props !is com.jesusdmedinac.jsontocompose.model.NodeProperties.TextProps) return@updateNodeRecursive node
+                node.copy(properties = props.copy(text = intent.text))
             }
             state.copy(rootNode = updatedRoot)
         }

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/EditorScreenModel.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/EditorScreenModel.kt
@@ -105,11 +105,15 @@ class EditorScreenModel : ScreenModel, EditorIntent.Visitor {
     override fun visit(intent: EditorIntent.UpdateModifier) {
         reduce { state ->
             val updatedRoot = state.rootNode.updateNodeRecursive(intent.id) { node ->
-                val newOperations = node.composeModifier.operations.toMutableList()
-                if (intent.index in newOperations.indices) {
-                    newOperations[intent.index] = intent.operation
+                val operations = node.composeModifier.operations
+                if (intent.index in operations.indices) {
+                    val newOperations = operations.toMutableList().apply {
+                        set(intent.index, intent.operation)
+                    }
+                    node.copy(composeModifier = com.jesusdmedinac.jsontocompose.model.ComposeModifier(newOperations))
+                } else {
+                    node
                 }
-                node.copy(composeModifier = com.jesusdmedinac.jsontocompose.model.ComposeModifier(newOperations))
             }
             state.copy(rootNode = updatedRoot)
         }
@@ -118,11 +122,15 @@ class EditorScreenModel : ScreenModel, EditorIntent.Visitor {
     override fun visit(intent: EditorIntent.DeleteModifier) {
         reduce { state ->
             val updatedRoot = state.rootNode.updateNodeRecursive(intent.id) { node ->
-                val newOperations = node.composeModifier.operations.toMutableList()
-                if (intent.index in newOperations.indices) {
-                    newOperations.removeAt(intent.index)
+                val operations = node.composeModifier.operations
+                if (intent.index in operations.indices) {
+                    val newOperations = operations.toMutableList().apply {
+                        removeAt(intent.index)
+                    }
+                    node.copy(composeModifier = com.jesusdmedinac.jsontocompose.model.ComposeModifier(newOperations))
+                } else {
+                    node
                 }
-                node.copy(composeModifier = com.jesusdmedinac.jsontocompose.model.ComposeModifier(newOperations))
             }
             state.copy(rootNode = updatedRoot)
         }

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/EditorScreenModel.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/EditorScreenModel.kt
@@ -64,23 +64,68 @@ class EditorScreenModel : ScreenModel, EditorIntent.Visitor {
     }
 
     override fun visit(intent: EditorIntent.UpdateNodeType) {
-        // To be implemented in next features
+        reduce { state ->
+            val updatedRoot = state.rootNode.updateNodeRecursive(intent.id) { node ->
+                if (!node.type.compatibleTypes().contains(intent.type)) return@updateNodeRecursive node
+                node.copy(
+                    type = intent.type,
+                    properties = intent.type.createDefaultProperties(
+                        preservedChildren = node.children().takeIf { it.isNotEmpty() },
+                        preservedChild = node.children().firstOrNull()
+                    )
+                )
+            }
+            state.copy(rootNode = updatedRoot)
+        }
     }
 
     override fun visit(intent: EditorIntent.UpdateNodeText) {
-        // To be implemented in next features
+        reduce { state ->
+            val updatedRoot = state.rootNode.updateNodeRecursive(intent.id) { node ->
+                val newProps = when (val props = node.properties) {
+                    is com.jesusdmedinac.jsontocompose.model.NodeProperties.TextProps -> props.copy(text = intent.text)
+                    else -> props
+                }
+                node.copy(properties = newProps)
+            }
+            state.copy(rootNode = updatedRoot)
+        }
     }
 
     override fun visit(intent: EditorIntent.AddModifier) {
-        // To be implemented in next features
+        reduce { state ->
+            val updatedRoot = state.rootNode.updateNodeRecursive(intent.id) { node ->
+                val newOperations = node.composeModifier.operations + intent.operation.createDefaultOperation()
+                node.copy(composeModifier = com.jesusdmedinac.jsontocompose.model.ComposeModifier(newOperations))
+            }
+            state.copy(rootNode = updatedRoot)
+        }
     }
 
     override fun visit(intent: EditorIntent.UpdateModifier) {
-        // To be implemented in next features
+        reduce { state ->
+            val updatedRoot = state.rootNode.updateNodeRecursive(intent.id) { node ->
+                val newOperations = node.composeModifier.operations.toMutableList()
+                if (intent.index in newOperations.indices) {
+                    newOperations[intent.index] = intent.operation
+                }
+                node.copy(composeModifier = com.jesusdmedinac.jsontocompose.model.ComposeModifier(newOperations))
+            }
+            state.copy(rootNode = updatedRoot)
+        }
     }
 
     override fun visit(intent: EditorIntent.DeleteModifier) {
-        // To be implemented in next features
+        reduce { state ->
+            val updatedRoot = state.rootNode.updateNodeRecursive(intent.id) { node ->
+                val newOperations = node.composeModifier.operations.toMutableList()
+                if (intent.index in newOperations.indices) {
+                    newOperations.removeAt(intent.index)
+                }
+                node.copy(composeModifier = com.jesusdmedinac.jsontocompose.model.ComposeModifier(newOperations))
+            }
+            state.copy(rootNode = updatedRoot)
+        }
     }
 
     override fun visit(intent: EditorIntent.SetLeftPanelDisplayed) {

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/NodePropertiesExtensions.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/NodePropertiesExtensions.kt
@@ -1,0 +1,144 @@
+package com.jesusdmedinac.compose.sdui.presentation.screenmodel
+
+import com.jesusdmedinac.jsontocompose.model.ComposeNode
+import com.jesusdmedinac.jsontocompose.model.NodeProperties
+
+/**
+ * Transforms all children of this NodeProperties using the provided transform function.
+ * This function handles the exhaustive mapping of all properties that contain ComposeNode instances.
+ * If the transform returns null, the child is removed (from lists) or set to null.
+ */
+fun NodeProperties.mapChildren(transform: (ComposeNode) -> ComposeNode?): NodeProperties = when (this) {
+    is NodeProperties.AlertDialogProps -> copy(
+        confirmButton = confirmButton?.let(transform),
+        dismissButton = dismissButton?.let(transform),
+        title = title?.let(transform),
+        text = text?.let(transform),
+        icon = icon?.let(transform)
+    )
+    is NodeProperties.BadgeProps -> this
+    is NodeProperties.BadgedBoxProps -> copy(
+        badge = badge?.let(transform),
+        child = child?.let(transform)
+    )
+    is NodeProperties.BottomBarProps -> copy(children = children?.mapNotNull(transform))
+    is NodeProperties.BottomNavigationItemProps -> copy(
+        label = label?.let(transform),
+        icon = icon?.let(transform)
+    )
+    is NodeProperties.BoxProps -> copy(children = children?.mapNotNull(transform))
+    is NodeProperties.ButtonProps -> copy(child = child?.let(transform))
+    is NodeProperties.CardProps -> copy(child = child?.let(transform))
+    is NodeProperties.CheckboxProps -> this
+    is NodeProperties.ChipProps -> copy(
+        label = label?.let(transform),
+        leadingIcon = leadingIcon?.let(transform)
+    )
+    is NodeProperties.ColumnProps -> copy(children = children?.mapNotNull(transform))
+    is NodeProperties.CustomProps -> this
+    is NodeProperties.DatePickerProps -> this
+    is NodeProperties.DividerProps -> this
+    is NodeProperties.ExtendedFabProps -> copy(
+        icon = icon?.let(transform),
+        text = text?.let(transform)
+    )
+    is NodeProperties.FabProps -> copy(icon = icon?.let(transform))
+    is NodeProperties.FilterChipProps -> copy(
+        label = label?.let(transform),
+        leadingIcon = leadingIcon?.let(transform)
+    )
+    is NodeProperties.FlowColumnProps -> copy(children = children?.mapNotNull(transform))
+    is NodeProperties.FlowRowProps -> copy(children = children?.mapNotNull(transform))
+    is NodeProperties.IconProps -> this
+    is NodeProperties.ImageProps -> this
+    is NodeProperties.InputChipProps -> copy(
+        label = label?.let(transform),
+        leadingIcon = leadingIcon?.let(transform),
+        trailingIcon = trailingIcon?.let(transform)
+    )
+    is NodeProperties.ListItemProps -> copy(
+        headlineContent = headlineContent?.let(transform),
+        supportingContent = supportingContent?.let(transform),
+        overlineContent = overlineContent?.let(transform),
+        leadingContent = leadingContent?.let(transform),
+        trailingContent = trailingContent?.let(transform)
+    )
+    is NodeProperties.ModalBottomSheetProps -> copy(child = child?.let(transform))
+    is NodeProperties.NavigationBarItemProps -> copy(
+        label = label?.let(transform),
+        icon = icon?.let(transform)
+    )
+    is NodeProperties.NavigationBarProps -> copy(children = children?.mapNotNull(transform))
+    is NodeProperties.NavigationDrawerItemProps -> copy(
+        label = label?.let(transform),
+        icon = icon?.let(transform),
+        badge = badge?.let(transform)
+    )
+    is NodeProperties.NavigationDrawerProps -> copy(
+        drawerContent = drawerContent?.mapNotNull(transform),
+        child = child?.let(transform)
+    )
+    is NodeProperties.NavigationRailItemProps -> copy(
+        label = label?.let(transform),
+        icon = icon?.let(transform)
+    )
+    is NodeProperties.NavigationRailProps -> copy(
+        header = header?.let(transform),
+        children = children?.mapNotNull(transform)
+    )
+    is NodeProperties.OutlinedCardProps -> copy(child = child?.let(transform))
+    is NodeProperties.PagerProps -> copy(pages = pages?.mapNotNull(transform))
+    is NodeProperties.PlainTooltipProps -> copy(anchor = anchor?.let(transform))
+    is NodeProperties.ProgressIndicatorProps -> this
+    is NodeProperties.RadioButtonProps -> this
+    is NodeProperties.RichTooltipProps -> copy(
+        anchor = anchor?.let(transform),
+        title = title?.let(transform),
+        text = text?.let(transform),
+        action = action?.let(transform)
+    )
+    is NodeProperties.RowProps -> copy(children = children?.mapNotNull(transform))
+    is NodeProperties.ScaffoldProps -> copy(
+        topBar = topBar?.let(transform),
+        bottomBar = bottomBar?.let(transform),
+        child = child?.let(transform),
+        floatingActionButton = floatingActionButton?.let(transform)
+    )
+    is NodeProperties.SearchBarProps -> copy(
+        placeholder = placeholder?.let(transform),
+        leadingIcon = leadingIcon?.let(transform),
+        trailingIcon = trailingIcon?.let(transform),
+        children = children?.mapNotNull(transform)
+    )
+    is NodeProperties.SegmentedButtonProps -> copy(
+        label = label?.let(transform),
+        icon = icon?.let(transform)
+    )
+    is NodeProperties.SegmentedButtonRowProps -> copy(children = children?.mapNotNull(transform))
+    is NodeProperties.SliderProps -> this
+    is NodeProperties.SnackbarHostProps -> this
+    is NodeProperties.SpacerProps -> this
+    is NodeProperties.SurfaceProps -> copy(child = child?.let(transform))
+    is NodeProperties.SwitchProps -> this
+    is NodeProperties.TabProps -> copy(
+        text = text?.let(transform),
+        icon = icon?.let(transform)
+    )
+    is NodeProperties.TabRowProps -> copy(children = children?.mapNotNull(transform))
+    is NodeProperties.TextFieldProps -> copy(
+        placeholder = placeholder?.let(transform),
+        label = label?.let(transform),
+        leadingIcon = leadingIcon?.let(transform),
+        trailingIcon = trailingIcon?.let(transform),
+        supportingText = supportingText?.let(transform),
+        prefix = prefix?.let(transform),
+        suffix = suffix?.let(transform)
+    )
+    is NodeProperties.TextProps -> this
+    is NodeProperties.TimePickerProps -> this
+    is NodeProperties.TopAppBarProps -> copy(
+        title = title?.let(transform),
+        navigationIcon = navigationIcon?.let(transform),
+        actions = actions?.mapNotNull(transform)
+    )
+}

--- a/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/ui/composable/ComposeNodeEditor.kt
+++ b/composy/src/commonMain/kotlin/com/jesusdmedinac/compose/sdui/presentation/ui/composable/ComposeNodeEditor.kt
@@ -47,6 +47,7 @@ import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Plus
 import com.jesusdmedinac.compose.sdui.presentation.screenmodel.ComposeTreeScreenModel
 import com.jesusdmedinac.compose.sdui.presentation.screenmodel.EditNodeBehavior
+import com.jesusdmedinac.compose.sdui.presentation.screenmodel.compatibleTypes
 import com.jesusdmedinac.compose.sdui.presentation.screenmodel.EditNodeScreenModel
 import com.jesusdmedinac.compose.sdui.presentation.screenmodel.EditNodeScreenState
 import com.jesusdmedinac.jsontocompose.model.ComposeModifier
@@ -229,7 +230,8 @@ private fun LazyListScope.composeTypeDropdownMenu(
                             .onComposeTypeMenuExpandedChange(false)
                     }
                 ) {
-                    ComposeType.entries.forEach { type ->
+                    val compatibleTypes = editingComposeNode?.compatibleTypes() ?: ComposeType.entries
+                    compatibleTypes.forEach { type ->
                         DropdownMenuItem(
                             onClick = {
                                 editNodeBehavior.onComposeTypeSelected(type)

--- a/composy/src/commonTest/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/ComposeNodeUtilsTest.kt
+++ b/composy/src/commonTest/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/ComposeNodeUtilsTest.kt
@@ -1,0 +1,56 @@
+package com.jesusdmedinac.compose.sdui.presentation.screenmodel
+
+import com.jesusdmedinac.jsontocompose.model.ComposeNode
+import com.jesusdmedinac.jsontocompose.model.ComposeType
+import com.jesusdmedinac.jsontocompose.model.NodeProperties
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ComposeNodeUtilsTest {
+
+    private fun textNode() = ComposeNode(
+        type = ComposeType.Text,
+        properties = NodeProperties.TextProps(text = "Text")
+    )
+
+    @Test
+    fun compatibleTypes_scaffoldWithChild_excludesLeafTypes() {
+        val scaffold = ComposeNode(
+            type = ComposeType.Scaffold,
+            properties = NodeProperties.ScaffoldProps(child = textNode())
+        )
+
+        val compatible = scaffold.compatibleTypes()
+
+        assertFalse(ComposeType.Text in compatible)
+        assertTrue(ComposeType.Column in compatible)
+        assertTrue(ComposeType.Card in compatible)
+    }
+
+    @Test
+    fun compatibleTypes_emptyScaffold_includesAllTypes() {
+        val scaffold = ComposeNode(
+            type = ComposeType.Scaffold,
+            properties = NodeProperties.ScaffoldProps()
+        )
+
+        assertEquals(ComposeType.entries.toList(), scaffold.compatibleTypes())
+    }
+
+    @Test
+    fun compatibleTypes_columnWithTwoChildren_excludesSingleChildContainers() {
+        val column = ComposeNode(
+            type = ComposeType.Column,
+            properties = NodeProperties.ColumnProps(children = listOf(textNode(), textNode()))
+        )
+
+        val compatible = column.compatibleTypes()
+
+        assertFalse(ComposeType.Button in compatible)
+        assertFalse(ComposeType.Text in compatible)
+        assertTrue(ComposeType.Row in compatible)
+        assertTrue(ComposeType.Box in compatible)
+    }
+}

--- a/composy/src/commonTest/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/EditorScreenModelTest.kt
+++ b/composy/src/commonTest/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/EditorScreenModelTest.kt
@@ -111,6 +111,50 @@ class EditorScreenModelTest {
     }
 
     @Test
+    fun testUpdateNodeType_incompatibleType_keepsRootNodeInstance() {
+        val screenModel = EditorScreenModel()
+        val rootId = screenModel.state.value.rootNode.id
+        screenModel.onIntent(EditorIntent.AddNode(rootId, ComposeType.Column))
+        val columnId = screenModel.state.value.rootNode.children().first().id
+        screenModel.onIntent(EditorIntent.AddNode(columnId, ComposeType.Text))
+        screenModel.onIntent(EditorIntent.AddNode(columnId, ComposeType.Text))
+        val rootBefore = screenModel.state.value.rootNode
+
+        // A Column with two children cannot become a single-child Button
+        screenModel.onIntent(EditorIntent.UpdateNodeType(columnId, ComposeType.Button))
+
+        assertSame(rootBefore, screenModel.state.value.rootNode)
+    }
+
+    @Test
+    fun testUpdateNodeType_emptyNode_convertsToAnyType() {
+        val screenModel = EditorScreenModel()
+        val rootId = screenModel.state.value.rootNode.id
+        screenModel.onIntent(EditorIntent.AddNode(rootId, ComposeType.Column))
+        val columnId = screenModel.state.value.rootNode.children().first().id
+
+        // A childless Column may become a leaf type
+        screenModel.onIntent(EditorIntent.UpdateNodeType(columnId, ComposeType.Text))
+
+        val converted = screenModel.state.value.rootNode.children().first()
+        assertEquals(ComposeType.Text, converted.type)
+        assertIs<NodeProperties.TextProps>(converted.properties)
+    }
+
+    @Test
+    fun testUpdateNodeText_nonTextNode_keepsRootNodeInstance() {
+        val screenModel = EditorScreenModel()
+        val rootId = screenModel.state.value.rootNode.id
+        screenModel.onIntent(EditorIntent.AddNode(rootId, ComposeType.Column))
+        val columnId = screenModel.state.value.rootNode.children().first().id
+        val rootBefore = screenModel.state.value.rootNode
+
+        screenModel.onIntent(EditorIntent.UpdateNodeText(columnId, "ignored"))
+
+        assertSame(rootBefore, screenModel.state.value.rootNode)
+    }
+
+    @Test
     fun testUpdateNodeRecursive_untouchedSiblingsKeepIdentity() {
         val screenModel = EditorScreenModel()
         val rootId = screenModel.state.value.rootNode.id

--- a/composy/src/commonTest/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/EditorScreenModelTest.kt
+++ b/composy/src/commonTest/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/EditorScreenModelTest.kt
@@ -8,6 +8,7 @@ import com.jesusdmedinac.jsontocompose.modifier.ModifierOperation
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlin.test.assertNotNull
 
@@ -83,5 +84,48 @@ class EditorScreenModelTest {
         
         ops = screenModel.state.value.rootNode.composeModifier.operations
         assertTrue(ops.isEmpty())
+    }
+
+    @Test
+    fun testUpdateModifier_outOfBoundsIndex_keepsRootNodeInstance() {
+        val screenModel = EditorScreenModel()
+        val rootId = screenModel.state.value.rootNode.id
+        screenModel.onIntent(EditorIntent.AddModifier(rootId, ModifierOperation.Padding))
+        val rootBefore = screenModel.state.value.rootNode
+
+        screenModel.onIntent(EditorIntent.UpdateModifier(rootId, 5, ComposeModifier.Operation.Padding(32)))
+
+        assertSame(rootBefore, screenModel.state.value.rootNode)
+    }
+
+    @Test
+    fun testDeleteModifier_outOfBoundsIndex_keepsRootNodeInstance() {
+        val screenModel = EditorScreenModel()
+        val rootId = screenModel.state.value.rootNode.id
+        screenModel.onIntent(EditorIntent.AddModifier(rootId, ModifierOperation.Padding))
+        val rootBefore = screenModel.state.value.rootNode
+
+        screenModel.onIntent(EditorIntent.DeleteModifier(rootId, 5))
+
+        assertSame(rootBefore, screenModel.state.value.rootNode)
+    }
+
+    @Test
+    fun testUpdateNodeRecursive_untouchedSiblingsKeepIdentity() {
+        val screenModel = EditorScreenModel()
+        val rootId = screenModel.state.value.rootNode.id
+        screenModel.onIntent(EditorIntent.AddNode(rootId, ComposeType.Text))
+        screenModel.onIntent(EditorIntent.AddNode(rootId, ComposeType.Text))
+        val childrenBefore = screenModel.state.value.rootNode.children()
+        val targetId = childrenBefore[0].id
+        val untouchedSibling = childrenBefore[1]
+
+        screenModel.onIntent(EditorIntent.UpdateNodeText(targetId, "Changed"))
+
+        val childrenAfter = screenModel.state.value.rootNode.children()
+        val targetProps = childrenAfter[0].properties
+        assertIs<NodeProperties.TextProps>(targetProps)
+        assertEquals("Changed", targetProps.text)
+        assertSame(untouchedSibling, childrenAfter[1])
     }
 }

--- a/composy/src/commonTest/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/EditorScreenModelTest.kt
+++ b/composy/src/commonTest/kotlin/com/jesusdmedinac/compose/sdui/presentation/screenmodel/EditorScreenModelTest.kt
@@ -1,0 +1,87 @@
+package com.jesusdmedinac.compose.sdui.presentation.screenmodel
+
+import com.jesusdmedinac.jsontocompose.model.ComposeNode
+import com.jesusdmedinac.jsontocompose.model.ComposeType
+import com.jesusdmedinac.jsontocompose.model.NodeProperties
+import com.jesusdmedinac.jsontocompose.model.ComposeModifier
+import com.jesusdmedinac.jsontocompose.modifier.ModifierOperation
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.test.assertNotNull
+
+class EditorScreenModelTest {
+
+    @Test
+    fun testUpdateNodeType_preservesChildrenIfCompatible() {
+        val screenModel = EditorScreenModel()
+        
+        // Root is Box. We add a Column.
+        screenModel.onIntent(EditorIntent.AddNode(screenModel.state.value.rootNode.id, ComposeType.Column))
+        val columnNode = screenModel.state.value.rootNode.children().first()
+        
+        // Add a Text child to the Column
+        screenModel.onIntent(EditorIntent.AddNode(columnNode.id, ComposeType.Text))
+        
+        // Verify state
+        val updatedColumn = screenModel.state.value.rootNode.children().first()
+        assertEquals(ComposeType.Column, updatedColumn.type)
+        assertEquals(1, updatedColumn.children().size)
+        
+        // Now dispatch UpdateNodeType to change Column to Row
+        screenModel.onIntent(EditorIntent.UpdateNodeType(updatedColumn.id, ComposeType.Row))
+        
+        val rowNode = screenModel.state.value.rootNode.children().first()
+        assertEquals(ComposeType.Row, rowNode.type)
+        assertIs<NodeProperties.RowProps>(rowNode.properties)
+        // Children should be preserved
+        assertEquals(1, rowNode.children().size)
+        assertEquals(ComposeType.Text, rowNode.children().first().type)
+    }
+
+    @Test
+    fun testUpdateNodeText() {
+        val screenModel = EditorScreenModel()
+        
+        // Add a Text node
+        screenModel.onIntent(EditorIntent.AddNode(screenModel.state.value.rootNode.id, ComposeType.Text))
+        val textNodeId = screenModel.state.value.rootNode.children().first().id
+        
+        // Update its text
+        screenModel.onIntent(EditorIntent.UpdateNodeText(textNodeId, "Hello MVI"))
+        
+        val updatedTextNode = screenModel.state.value.rootNode.children().first()
+        val props = updatedTextNode.properties
+        assertIs<NodeProperties.TextProps>(props)
+        assertEquals("Hello MVI", props.text)
+    }
+
+    @Test
+    fun testModifiersCRUD() {
+        val screenModel = EditorScreenModel()
+        val rootId = screenModel.state.value.rootNode.id
+        
+        // ADD
+        screenModel.onIntent(EditorIntent.AddModifier(rootId, ModifierOperation.Padding))
+        
+        var ops = screenModel.state.value.rootNode.composeModifier.operations
+        assertEquals(1, ops.size)
+        assertIs<ComposeModifier.Operation.Padding>(ops[0])
+        assertEquals(0, (ops[0] as ComposeModifier.Operation.Padding).value)
+        
+        // UPDATE
+        val updatedOp = ComposeModifier.Operation.Padding(32)
+        screenModel.onIntent(EditorIntent.UpdateModifier(rootId, 0, updatedOp))
+        
+        ops = screenModel.state.value.rootNode.composeModifier.operations
+        assertEquals(1, ops.size)
+        assertEquals(32, (ops[0] as ComposeModifier.Operation.Padding).value)
+        
+        // DELETE
+        screenModel.onIntent(EditorIntent.DeleteModifier(rootId, 0))
+        
+        ops = screenModel.state.value.rootNode.composeModifier.operations
+        assertTrue(ops.isEmpty())
+    }
+}

--- a/docs/projects/phase-1.5-mvi-architecture/PROGRESS.md
+++ b/docs/projects/phase-1.5-mvi-architecture/PROGRESS.md
@@ -13,9 +13,9 @@ This phase focuses on migrating the scattered ScreenModels to a single, unidirec
 - [x] Scenario: Migrate Reorder Node
 
 ## Feature: MVI Editor Operations
-- [ ] Scenario: Migrate Update Node Type
-- [ ] Scenario: Migrate Update Node Text
-- [ ] Scenario: Migrate Modifiers CRUD
+- [x] Scenario: Migrate Update Node Type
+- [x] Scenario: Migrate Update Node Text
+- [x] Scenario: Migrate Modifiers CRUD
 
 ## Feature: MVI UI State
 - [ ] Scenario: Migrate Panel Display toggles

--- a/docs/projects/phase-1.5-mvi-architecture/features/mvi_editor_operations.feature
+++ b/docs/projects/phase-1.5-mvi-architecture/features/mvi_editor_operations.feature
@@ -1,19 +1,26 @@
 Feature: MVI Editor Operations
-  As a developer
-  I want to handle node property and modifier edits through Intents
-  So that modifying a node safely produces a new root tree state
+  As a developer using Composy
+  I want to modify the type, text, and modifiers of nodes via a unified MVI intent
+  So that the UI updates predictively based on a centralized immutable state flow
 
   Scenario: Migrate Update Node Type
-    Given a selected node
-    When the UpdateNodeType intent is dispatched
-    Then the EditorState should update the root node, mapping properties properly
+    Given a node of a specific type exists in the EditorState
+    When the user dispatches the EditorIntent.UpdateNodeType to a new compatible type
+    Then the node type should change to the new type
+    And the children should be preserved in the new container if compatible
+    And incompatible types should not be presented in the UI
 
   Scenario: Migrate Update Node Text
-    Given a selected text node
-    When the UpdateNodeText intent is dispatched
-    Then the EditorState should update the root node with the new text
+    Given a node with TextProps exists in the EditorState
+    When the user dispatches the EditorIntent.UpdateNodeText with "New Text"
+    Then the node's properties should be updated to reflect "New Text"
+    And the node ID and parent reference should remain the same
 
   Scenario: Migrate Modifiers CRUD
-    Given a selected node
-    When AddModifier, UpdateModifier, or DeleteModifier intents are dispatched
-    Then the EditorState should update the root node's modifiers accordingly
+    Given a node with a ComposeModifier exists in the EditorState
+    When the user dispatches EditorIntent.AddModifier
+    Then a new modifier operation should be appended
+    When the user dispatches EditorIntent.UpdateModifier at an index
+    Then the specific operation should be replaced
+    When the user dispatches EditorIntent.DeleteModifier at an index
+    Then the specific operation should be removed from the list

--- a/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/model/ComposeType.kt
+++ b/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/model/ComposeType.kt
@@ -195,16 +195,4 @@ enum class ComposeType {
 
         else -> false
     }
-
-    /**
-     * Returns a list of ComposeTypes that this type can safely be converted to.
-     * Layouts can be converted to other Layouts.
-     * Single child containers can be converted to other single child containers.
-     * Otherwise, returns all types.
-     */
-    fun compatibleTypes(): List<ComposeType> = when {
-        isLayout() -> ComposeType.entries.filter { it.isLayout() }
-        hasChild() -> ComposeType.entries.filter { it.hasChild() }
-        else -> ComposeType.entries
-    }
 }

--- a/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/model/ComposeType.kt
+++ b/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/model/ComposeType.kt
@@ -195,4 +195,16 @@ enum class ComposeType {
 
         else -> false
     }
+
+    /**
+     * Returns a list of ComposeTypes that this type can safely be converted to.
+     * Layouts can be converted to other Layouts.
+     * Single child containers can be converted to other single child containers.
+     * Otherwise, returns all types.
+     */
+    fun compatibleTypes(): List<ComposeType> = when {
+        isLayout() -> ComposeType.entries.filter { it.isLayout() }
+        hasChild() -> ComposeType.entries.filter { it.hasChild() }
+        else -> ComposeType.entries
+    }
 }

--- a/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/modifier/ModifierMapper.kt
+++ b/library/src/commonMain/kotlin/com/jesusdmedinac/jsontocompose/modifier/ModifierMapper.kt
@@ -81,6 +81,38 @@ enum class ModifierOperation {
     MaxHeight,
     AnimateContentSize,
     TestTag;
+
+    fun createDefaultOperation(): ComposeModifier.Operation = when (this) {
+        Padding -> ComposeModifier.Operation.Padding(0)
+        FillMaxSize -> ComposeModifier.Operation.FillMaxSize
+        FillMaxWidth -> ComposeModifier.Operation.FillMaxWidth
+        FillMaxHeight -> ComposeModifier.Operation.FillMaxHeight
+        Width -> ComposeModifier.Operation.Width(0)
+        Height -> ComposeModifier.Operation.Height(0)
+        BackgroundColor -> ComposeModifier.Operation.BackgroundColor("#00000000")
+        Border -> ComposeModifier.Operation.Border(1, "#FF000000", ComposeShape.Rectangle)
+        Shadow -> ComposeModifier.Operation.Shadow(0, ComposeShape.Rectangle, false)
+        Clip -> ComposeModifier.Operation.Clip(ComposeShape.Rectangle)
+        Background -> ComposeModifier.Operation.Background("#00000000", ComposeShape.Rectangle)
+        Alpha -> ComposeModifier.Operation.Alpha(1f)
+        Rotate -> ComposeModifier.Operation.Rotate(0f)
+        Clickable -> ComposeModifier.Operation.Clickable("")
+        Weight -> ComposeModifier.Operation.Weight(1f)
+        VerticalScroll -> ComposeModifier.Operation.VerticalScroll
+        HorizontalScroll -> ComposeModifier.Operation.HorizontalScroll
+        Offset -> ComposeModifier.Operation.Offset(0, 0)
+        Size -> ComposeModifier.Operation.Size(0, 0)
+        WrapContentWidth -> ComposeModifier.Operation.WrapContentWidth
+        WrapContentHeight -> ComposeModifier.Operation.WrapContentHeight
+        AspectRatio -> ComposeModifier.Operation.AspectRatio(1f)
+        ZIndex -> ComposeModifier.Operation.ZIndex(0f)
+        MinWidth -> ComposeModifier.Operation.MinWidth(0)
+        MinHeight -> ComposeModifier.Operation.MinHeight(0)
+        MaxWidth -> ComposeModifier.Operation.MaxWidth(0)
+        MaxHeight -> ComposeModifier.Operation.MaxHeight(0)
+        AnimateContentSize -> ComposeModifier.Operation.AnimateContentSize
+        TestTag -> ComposeModifier.Operation.TestTag("")
+    }
 }
 
 /**


### PR DESCRIPTION
Resolves #97. Migrated node operations (Update NodeType, Update Text, Modifiers CRUD) to MVI using EditorIntent and EditorState. Ensures immutability via proper node copying and tree recreation. Covered with TDD.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added editor support for changing node types, updating text, and managing modifiers.
  * Node type selection now displays only compatible options.
  * Compatible child content is preserved when changing node types.
  * Added default values for newly created modifier operations.
  * Recursive updates now preserve unaffected parts of the editor tree.

* **Documentation**
  * Updated MVI editor operation documentation and completion progress.

* **Tests**
  * Added coverage for node updates, modifier CRUD, compatibility rules, edge cases, and structural preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->