### PR TITLE
test: update library commonTest for required ComposeNode.properties

### DIFF
--- a/library/src/commonTest/kotlin/com/jesusdmedinac/jsontocompose/model/ComposeDocumentTest.kt
+++ b/library/src/commonTest/kotlin/com/jesusdmedinac/jsontocompose/model/ComposeDocumentTest.kt
@@ -20,7 +20,7 @@ class ComposeDocumentTest {
                 "switch_state" to JsonPrimitive(false),
                 "text_value" to JsonPrimitive(""),
             ),
-            root = ComposeNode(type = ComposeType.Text),
+            root = ComposeNode(type = ComposeType.Text, properties = NodeProperties.TextProps()),
         )
 
         assertEquals(2, doc.initialState.size)
@@ -37,7 +37,7 @@ class ComposeDocumentTest {
                 "count" to JsonPrimitive(42),
                 "opacity" to JsonPrimitive(0.75f),
             ),
-            root = ComposeNode(type = ComposeType.Text),
+            root = ComposeNode(type = ComposeType.Text, properties = NodeProperties.TextProps()),
         )
 
         assertEquals(4, doc.initialState.size)
@@ -61,7 +61,7 @@ class ComposeDocumentTest {
                     ComposeAction.Log(message = "Dialog dismissed"),
                 ),
             ),
-            root = ComposeNode(type = ComposeType.Text),
+            root = ComposeNode(type = ComposeType.Text, properties = NodeProperties.TextProps()),
         )
 
         assertEquals(2, doc.actions.size)

--- a/library/src/commonTest/kotlin/com/jesusdmedinac/jsontocompose/model/ComposeNodeTreeTest.kt
+++ b/library/src/commonTest/kotlin/com/jesusdmedinac/jsontocompose/model/ComposeNodeTreeTest.kt
@@ -11,7 +11,7 @@ class ComposeNodeTreeTest {
 
     @Test
     fun countLevelsForRootNodeIsZero() {
-        val root = ComposeNode(type = ComposeType.Text)
+        val root = ComposeNode(type = ComposeType.Text, properties = NodeProperties.TextProps())
         assertEquals(0, root.countLevels())
     }
 
@@ -19,10 +19,10 @@ class ComposeNodeTreeTest {
 
     @Test
     fun countLevelsForNestedNodeReturnsDepth() {
-        val grandparent = ComposeNode(type = ComposeType.Column)
-        val parent = ComposeNode(type = ComposeType.Row, parent = grandparent)
-        val child = ComposeNode(type = ComposeType.Box, parent = parent)
-        val leaf = ComposeNode(type = ComposeType.Text, parent = child)
+        val grandparent = ComposeNode(type = ComposeType.Column, properties = NodeProperties.ColumnProps())
+        val parent = ComposeNode(type = ComposeType.Row, properties = NodeProperties.RowProps(), parent = grandparent)
+        val child = ComposeNode(type = ComposeType.Box, properties = NodeProperties.BoxProps(), parent = parent)
+        val leaf = ComposeNode(type = ComposeType.Text, properties = NodeProperties.TextProps(), parent = child)
 
         assertEquals(0, grandparent.countLevels())
         assertEquals(1, parent.countLevels())
@@ -34,7 +34,7 @@ class ComposeNodeTreeTest {
 
     @Test
     fun parentsForRootNodeIsEmpty() {
-        val root = ComposeNode(type = ComposeType.Text)
+        val root = ComposeNode(type = ComposeType.Text, properties = NodeProperties.TextProps())
         assertTrue(root.parents().isEmpty())
     }
 
@@ -42,9 +42,9 @@ class ComposeNodeTreeTest {
 
     @Test
     fun parentsForNestedNodeReturnsAncestorsInOrder() {
-        val grandparent = ComposeNode(type = ComposeType.Column)
-        val parent = ComposeNode(type = ComposeType.Row, parent = grandparent)
-        val child = ComposeNode(type = ComposeType.Text, parent = parent)
+        val grandparent = ComposeNode(type = ComposeType.Column, properties = NodeProperties.ColumnProps())
+        val parent = ComposeNode(type = ComposeType.Row, properties = NodeProperties.RowProps(), parent = grandparent)
+        val child = ComposeNode(type = ComposeType.Text, properties = NodeProperties.TextProps(), parent = parent)
 
         val parents = child.parents()
         assertEquals(2, parents.size)
@@ -133,23 +133,26 @@ class ComposeNodeTreeTest {
     // --- Scenario 9: id generation for root node ---
 
     @Test
-    fun idForRootNodeIsZero() {
-        val root = ComposeNode(type = ComposeType.Text)
-        assertEquals("0", root.id)
+    fun idForRootNodeUsesRootPrefix() {
+        val root = ComposeNode(type = ComposeType.Text, properties = NodeProperties.TextProps())
+        assertTrue(root.id.matches(Regex("root_\\d+")), "Unexpected root id: ${root.id}")
     }
 
     // --- Scenario 10: id generation for child node ---
 
     @Test
-    fun idForChildNodeIncludesParentIdTypeAndSiblingIndex() {
-        val parent = ComposeNode(type = ComposeType.Column)
+    fun idForChildNodeIncludesParentIdAndType() {
+        val parent = ComposeNode(type = ComposeType.Column, properties = NodeProperties.ColumnProps())
         val child = ComposeNode(
             type = ComposeType.Text,
+            properties = NodeProperties.TextProps(),
             parent = parent
         )
 
-        // parent.id = "0", child has no children() so size = 0, index = 0 + 1 = 1
-        assertEquals("0_Text_1", child.id)
+        assertTrue(
+            child.id.matches(Regex("${Regex.escape(parent.id)}_Text_\\d+")),
+            "Unexpected child id: ${child.id}",
+        )
     }
 
     // --- Scenario 11: toString produces valid JSON ---

--- a/library/src/commonTest/kotlin/com/jesusdmedinac/jsontocompose/validation/ComposeNodeValidatorTest.kt
+++ b/library/src/commonTest/kotlin/com/jesusdmedinac/jsontocompose/validation/ComposeNodeValidatorTest.kt
@@ -615,10 +615,10 @@ class ComposeNodeValidatorTest {
     }
 
     @Test
-    fun nullPropertiesProducesNoError() {
+    fun emptyPropertiesProducesNoError() {
         val node = ComposeNode(
             type = ComposeType.Text,
-            properties = null,
+            properties = NodeProperties.TextProps(),
         )
 
         val result = node.validate()


### PR DESCRIPTION
## Summary

`ComposeNode`'s `properties` constructor parameter became non-null and required, but the library `commonTest` files were never updated, so `:library:compileTestKotlinDesktop` fails on `main`.

- **ComposeDocumentTest.kt** — pass `NodeProperties.TextProps()` to the three bare `ComposeNode(type = ComposeType.Text)` constructors.
- **ComposeNodeTreeTest.kt** — pass matching props (`ColumnProps`/`RowProps`/`BoxProps`/`TextProps`) to every constructor; rewrite the two id-generation assertions to the current `root_<counter>` / `<parentId>_<Type>_<counter>` scheme (the old `"0"` / `"0_Text_1"` expectations would fail at runtime, and the global counter makes exact values order-dependent, so they now match by regex).
- **ComposeNodeValidatorTest.kt** — `properties = null` is no longer legal; replaced `nullPropertiesProducesNoError` with `emptyPropertiesProducesNoError` using `NodeProperties.TextProps()`.

## Test plan

- `./gradlew :library:desktopTest` — 431 tests, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)