### PR TITLE
docs: plan MVI UI Integration feature for phase-1.5

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,7 +4,7 @@
 > **Mandatory Workflow Requirement:** To avoid a `NullPointerException` (NPE) in Android Unit Tests, agents **must NOT** run UI tests using `./gradlew :library:test`. Instead, always use `./gradlew :library:desktopTest` for primary validation.
 > See the [Compose Multiplatform UI Testing Guide](docs/COMPOSE_MULTIPLATFORM_TESTING.md#mandatory-testing-rules-for-agents) for more details.
 
-> Last updated: 2025-05-07
+> Last updated: 2026-07-16
 
 ## Overall Progress
 
@@ -14,11 +14,11 @@
 | 2   | phase-actions-system                                              | `library/`    | 37        | 37        | **100%** |
 | 3   | phase-demo-showcase                                               | `composeApp/` | 36        | 36        | **100%** |
 | 4   | [phase-3-expand-library](#phase-3-expand-library)               | `library/`    | 239       | 239       | **100%** |
-| 5   | [phase-1.5-mvi-architecture](#phase-15-mvi-architecture)        | `composy/`    | 12        | 9         | **75%**  |
+| 5   | [phase-1.5-mvi-architecture](#phase-15-mvi-architecture)        | `composy/`    | 16        | 9         | **56%**  |
 | 6   | [phase-2-editor-mvp](#phase-2-editor-mvp)                       | `composy/`    | 58        | 19        | **32%**  |
 | 7   | [phase-4-semantics-testability](#phase-4-semantics-testability) | `library/`    | 30        | 0         | **0%**   |
 | 8   | [phase-3-differentiators](#phase-3-differentiators)             | Multi-module  | 37        | 0         | **0%**   |
-|     | **TOTAL**                                                         |               | **632**   | **527**   | **83%**  |
+|     | **TOTAL**                                                         |               | **636**   | **527**   | **83%**  |
 
 ```text
 Progress: [█████████████████████████████████░░░░░░] 83%
@@ -66,7 +66,7 @@ Progress: [███████████████████████
 
 ### phase-1.5-mvi-architecture
 
-**Status:** 🏗️ In Progress (9/12 — 75%)
+**Status:** 🏗️ In Progress (9/16 — 56%)
 **Module:** `composy/`
 **Depends on:** Initial Editor MVP work.
 **Description:** Refactors scattered ScreenModels into a centralized MVI architecture (EditorState + EditorIntent) to solve state desynchronization bugs and enable predictable data flow.

--- a/docs/projects/phase-1.5-mvi-architecture/PROGRESS.md
+++ b/docs/projects/phase-1.5-mvi-architecture/PROGRESS.md
@@ -21,3 +21,13 @@ This phase focuses on migrating the scattered ScreenModels to a single, unidirec
 - [ ] Scenario: Migrate Panel Display toggles
 - [ ] Scenario: Migrate Viewport Modes
 - [ ] Scenario: Migrate Keyword Search
+
+## Feature: MVI UI Integration
+- [ ] Scenario: Tree panel dispatches intents
+- [ ] Scenario: Node editor dispatches intents
+- [ ] Scenario: Preview renders from EditorState
+- [ ] Scenario: Legacy ScreenModels removed
+
+> **Exit criterion:** the phase is complete only when the UI runs entirely on
+> `EditorScreenModel` and the legacy ScreenModels are deleted — not merely when
+> all state has been migrated into `EditorState`.

--- a/docs/projects/phase-1.5-mvi-architecture/features/mvi_ui_integration.feature
+++ b/docs/projects/phase-1.5-mvi-architecture/features/mvi_ui_integration.feature
@@ -25,4 +25,5 @@ Feature: MVI UI Integration
     Given all UI components consume EditorScreenModel
     When the legacy ScreenModels are deleted
     Then the project should compile and all tests should pass
-    And no UI code should reference EditNodeScreenModel or ComposeTreeScreenModel
+    And no code should reference ComposeTreeScreenModel, EditNodeScreenModel, ComposeComponentsScreenModel, or MainScreenModel
+    And AuthScreenModel should remain, as authentication is outside the editor's MVI scope

--- a/docs/projects/phase-1.5-mvi-architecture/features/mvi_ui_integration.feature
+++ b/docs/projects/phase-1.5-mvi-architecture/features/mvi_ui_integration.feature
@@ -1,0 +1,28 @@
+Feature: MVI UI Integration
+  As a developer
+  I want the editor UI to dispatch EditorIntents and render from EditorState
+  So that the centralized MVI flow drives the application and legacy ScreenModels can be removed
+
+  Scenario: Tree panel dispatches intents
+    Given the compose tree panel
+    When the user selects, adds, deletes, or reorders a node
+    Then the corresponding EditorIntent should be dispatched to EditorScreenModel
+    And the tree should render from EditorState.rootNode
+
+  Scenario: Node editor dispatches intents
+    Given the node editor panel with a selected node
+    When the user changes the node type, text, or modifiers
+    Then EditorIntent.UpdateNodeType, UpdateNodeText, or the modifier intents should be dispatched
+    And the editor fields should render from the selected node in EditorState
+
+  Scenario: Preview renders from EditorState
+    Given the real-time preview
+    When any EditorIntent updates the root node
+    Then the preview should recompose from EditorState.rootNode
+    And changing a node type should never make the preview disappear (regression for #86)
+
+  Scenario: Legacy ScreenModels removed
+    Given all UI components consume EditorScreenModel
+    When the legacy ScreenModels are deleted
+    Then the project should compile and all tests should pass
+    And no UI code should reference EditNodeScreenModel or ComposeTreeScreenModel


### PR DESCRIPTION
Adds the **MVI UI Integration** feature to phase-1.5 planning (tracked in #99).

The existing 12 phase-1.5 scenarios build `EditorState`/`EditorIntent`/`EditorScreenModel`, but none makes the UI consume them — the editor still runs on the legacy ScreenModels, so the phase's goal (eliminating state desync) isn't reachable by the current scenario list alone.

Changes:
- New `docs/projects/phase-1.5-mvi-architecture/features/mvi_ui_integration.feature` with 4 scenarios: tree panel dispatches intents, node editor dispatches intents, preview renders from EditorState (regression for #86), legacy ScreenModels removed.
- Phase PROGRESS.md: new feature section + explicit exit criterion.
- Root PROGRESS.md: phase-1.5 now 9/16 (56%), total 636 scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)